### PR TITLE
update SQL-Query to find MIN- and MAX-Price

### DIFF
--- a/system/modules/isotope/IsotopeProduct.php
+++ b/system/modules/isotope/IsotopeProduct.php
@@ -227,24 +227,19 @@ class IsotopeProduct extends Controller
 						// Add "price_tiers" to variant attributes, so the field is updated through ajax
 						$this->arrVariantAttributes[] = 'price_tiers';
 
-						$objProduct = $this->Database->execute("SELECT MIN(price) AS low_price, MAX(price) AS high_price
-																FROM tl_iso_price_tiers
-																WHERE pid IN
-																(
-																	SELECT id
-																	FROM
-																	(
-																		SELECT p1.id, p1.pid FROM tl_iso_prices p1 LEFT JOIN tl_iso_products p2 ON p1.pid=p2.id
-																		WHERE
-																			p1.pid IN (" . implode(',', $this->arrVariantOptions['ids']) . ")
-																			AND p1.config_id IN (" . (int) $this->Isotope->Config->id . ",0)
-																			AND p1.member_group IN(" . ((FE_USER_LOGGED_IN === true && count($this->User->groups)) ? (implode(',', $this->User->groups).',') : '') . "0)
-																			AND (p1.start='' OR p1.start<$time)
-																			AND (p1.stop='' OR p1.stop>$time)
-																		ORDER BY p1.config_id DESC, " . ((FE_USER_LOGGED_IN === true && count($this->User->groups)) ? ('p1.member_group=' . implode(' DESC, p1.member_group=', $this->User->groups) . ' DESC') : 'p1.member_group DESC') . ", p1.start DESC, p1.stop DESC
-																	) AS p
-																	GROUP BY pid
-																)");
+            $objProduct = $this->Database->execute
+                          ("SELECT MIN(price) AS low_price, MAX(price) AS high_price
+                            FROM tl_iso_price_tiers
+                            WHERE pid IN
+                            (
+                             SELECT p1.id FROM tl_iso_prices p1 LEFT JOIN tl_iso_products p2 ON p1.pid=p2.id
+                             WHERE p1.pid IN (" . implode(',', $this->arrVariantOptions['ids']) . ")
+                              AND p1.config_id IN (" . (int) $this->Isotope->Config->id . ",0)
+                              AND p1.member_group IN(" . ((FE_USER_LOGGED_IN === true && count($this->User->groups)) ? (implode(',', $this->User->groups).',') : '') . "0)
+                              AND (p1.start='' OR p1.start<$time)
+                              AND (p1.stop='' OR p1.stop>$time)
+                            )"
+                          );    
 					}
 					else
 					{


### PR DESCRIPTION
Es macht keinen Sinn die Ausgabe vorher zu sortieren, und anschließend zu gruppieren, da wir den Min- und Max-Preis suchen.

Diesen bestimmt die MySQL immer nur einmal, egal ob der Wert mehrfach vorkommt oder nicht. Zudem dauert die Gruppierung bei > 22.000 Einträgen fast 30 Sekunden, was bei einem Online-Shop zu lange ist. 

Die Werte die nicht benötigt werden, werden vorab in dem Sub-SQL-Query aussortiert.  
