### PR TITLE
Prevent the modified breadcrumb menu from having two active items

### DIFF
--- a/system/modules/isotope/IsotopeFrontend.php
+++ b/system/modules/isotope/IsotopeFrontend.php
@@ -1671,6 +1671,11 @@ $endScript";
 
 				$arrItems = array_reverse(array_merge($arrResult, $arrItems));
 
+				// Reconvert the last item into a link
+				$i = count($arrItems) - 1;
+				$arrItems[$i]['isActive'] = false;
+				$arrItems[$i]['href'] = $this->generateFrontendUrl($arrItems[$i]['data']);
+
 				// Add the reader as breadcrumb item
 				$arrItems[] = array
 				(


### PR DESCRIPTION
The last element of `$arrItems` is already marked as active before you add the reader in line 1674. You then end up with two active items and cannot go back to the page without the reader.
