### PR TITLE
Fixed: Insert Tag Problem in E-Mail Templates

### DIFF
--- a/system/modules/isotope/ModuleIsotopeCheckout.php
+++ b/system/modules/isotope/ModuleIsotopeCheckout.php
@@ -1082,6 +1082,15 @@ class ModuleIsotopeCheckout extends ModuleIsotope
 			'cart_html'			=> $this->replaceInsertTags($this->Isotope->Cart->getProducts('iso_products_html')),
 		));
 
+		// Replace the insert tags in the variables of the email template
+		if (count($arrData) > 0)
+		{
+			foreach ($arrData as $k => $v)
+			{
+				$arrData[$k] = trim($this->replaceInsertTags($arrData[$k]));
+			}
+		}
+
 		$objOrder->email_data = $arrData;
 		$objOrder->save();
 	}


### PR DESCRIPTION
Ich bin auf das Problem gestoßen, dass die **Bestellbestätigung E-Mail** Insert Tags enthält, welche nicht übersetzt werden. Beim genaueren untersuchen des Problems ist mir aufgefallen, dass sich die Insert Tags innerhalb der E-Mail Template Variablen (z.B. ##cart_html##) befinden.
Die **Lösung** des Problems ist es nun, die **Insert Tags** innerhalb der E-Mail Template **Variablen** zu **ersetzen**.
Der angehängte Pull Request löst das Problem.
