### PR TITLE
Postsale.php overwrites customer products

### DIFF
--- a/system/modules/isotope/config/config.php
+++ b/system/modules/isotope/config/config.php
@@ -234,12 +234,16 @@ $GLOBALS['ISO_GAL']['zoom']						= 'ZoomGallery';
 /**
  * Product types
  */
-$GLOBALS['ISO_PRODUCT'] = array
+$GLOBALS['ISO_PRODUCT'] = array_merge_recursive
 (
-	'regular' => array
+	(array) $GLOBALS['ISO_PRODUCT'],
+	array
 	(
-		'class'	=> 'IsotopeProduct',
-	),
+		'regular' => array
+		(
+			'class' => 'IsotopeProduct',
+		),
+	)
 );
 
 


### PR DESCRIPTION
If we have a new product set in globals "ISO_PRODUCT" and go through the checkout with paypal, the postsale class overwrites the new product in globals array on IPN connection.
