### PR TITLE
Fixed shipping availability in checkout

### DIFF
--- a/system/modules/isotope/IsotopeShipping.php
+++ b/system/modules/isotope/IsotopeShipping.php
@@ -155,6 +155,13 @@ abstract class IsotopeShipping extends Frontend
 
 					foreach ($arrProducts as $objProduct)
 					{
+
+						// Shipping exempt items should not affect availability of shipping method
+						if ($objProduct->shipping_exempt)
+						{
+							continue;
+						}
+
 						if (!in_array($objProduct->type, $arrTypes))
 						{
 							return false;


### PR DESCRIPTION
Problem description/How to reproduce:
Product type TA is configured as 'shipping_exempt'.
Product type TB is shippable (e.g. by shipping module 'mail')

Shipping module 'mail' is restricted (beside other types) to product type TB.
Do not add product type TA to restricted product types of shipping module 'mail'.

If you add products of both types (TA and TB) to the cart, you can't choose a shipping method.
ModuleIsotopeCheckout::getShippingModulesInterface() checks availability of the shipping method/module,
which will result in false.
