### PR TITLE
IsotopeShipping->getSurcharge() now returns surcharge even if price is 0

### DIFF
--- a/system/modules/isotope/IsotopeShipping.php
+++ b/system/modules/isotope/IsotopeShipping.php
@@ -281,11 +281,6 @@ abstract class IsotopeShipping extends Frontend
 	 */
 	public function getSurcharge($objCollection)
 	{
-		if ($this->arrData['price'] == 0)
-		{
-			return false;
-		}
-
 		return $this->Isotope->calculateSurcharge(
 								$this->arrData['price'],
 								($GLOBALS['TL_LANG']['MSC']['shippingLabel'] . ' (' . $this->label . ')'),

--- a/system/modules/isotope/ShippingFlat.php
+++ b/system/modules/isotope/ShippingFlat.php
@@ -58,11 +58,6 @@ class ShippingFlat extends IsotopeShipping
 	{
 		$fltPrice = $this->getPrice();
 
-		if ($fltPrice == 0)
-		{
-			return false;
-		}
-
 		return $this->Isotope->calculateSurcharge(
 								$fltPrice,
 								($GLOBALS['TL_LANG']['MSC']['shippingLabel'] . ' (' . $this->label . ')'),


### PR DESCRIPTION
At least in germany the shipping cost must be displayed even if they are 0.
