### PR TITLE
Paypal encoding fix

### DIFF
--- a/system/modules/isotope/PaymentPaypal.php
+++ b/system/modules/isotope/PaymentPaypal.php
@@ -82,7 +82,7 @@ class PaymentPaypal extends IsotopePayment
 	public function processPostSale()
 	{
 		$objRequest = new Request();
-		$objRequest->send(('https://www.' . ($this->debug ? 'sandbox.' : '') . 'paypal.com/cgi-bin/webscr?cmd=_notify-validate'), http_build_query($_POST, '', '&'), 'post');
+		$objRequest->send(('https://www.' . ($this->debug ? 'sandbox.' : '') . 'paypal.com/cgi-bin/webscr?cmd=_notify-validate'), file_get_contents("php://input"), 'post');
 
 		if ($objRequest->hasError())
 		{


### PR DESCRIPTION
Hi isotope team,

paypal sends the ipn request "windows-whatever" encoded (maybe only in sendbox). The processPostSale reassemble all post parameters but sometimes killes the encoding which will result in an "invalid" response by paypal. If you ping back the raw data it works fine.

Volker
