### PR TITLE
Wrong contao version required in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require":{
         "php":">=5.3.2",
-        "contao":">=2.3",
+        "contao":">=3.2",
         "contao-community-alliance/composer-installer":"*",
         "contao-legacy/NamespaceClassLoader":">=1.0.1",
         "contao-legacy/conditionalselectmenu":">=1.1.3",


### PR DESCRIPTION
The wrong version of contao was required which causes an error during installation via composer.
