### PR TITLE
Allow contao 3.2-RC1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require":{
         "php":">=5.3.2",
-        "contao/core":">=3.2",
+        "contao/core":">=3.2-RC1",
         "contao-community-alliance/composer-installer":"*",
         "contao-legacy/NamespaceClassLoader":">=1.0.1",
         "contao-legacy/conditionalselectmenu":">=1.1.3",


### PR DESCRIPTION
The constraint `>=3.2` for `contao/core` only match stable packages.
It must be specified as `>=3.2-RC1` to allow the RC1 release.
