### PR TITLE
Update Standard.php

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -144,10 +144,6 @@ class Standard extends Product implements IsotopeProduct, WeightAggregate
             return false;
         }
 
-        // Check if "advanced price" is available
-        if (null === $this->getPrice() && (in_array('price', $this->getAttributes()) || $this->hasVariantPrices())) {
-            return false;
-        }
 
         return true;
     }


### PR DESCRIPTION
die Abfrage insbesondere $this->getPrice() braucht pro Produkt 5 Datenbankabfragen. 
In der Funktion generate findet sich auch nochmal eine Abfrage das getPrice() !==Null ist.
Daher würde ich meinen das man zuliebe der Performance an dieser Stelle darauf verzichten sollte - oder?
