### PR TITLE
Fixed incorrect display of variant attributes in PAYONE

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Payment/Payone.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Payone.php
@@ -111,8 +111,8 @@ class Payone extends Postsale implements IsotopePayment
 
                 array_walk(
                     $arrOptions,
-                    function($option) {
-                        return $option['label'] . ': ' . $option['value'];
+                    function(&$option) {
+                        $option = $option['label'] . ': ' . $option['value'];
                     }
                 );
 


### PR DESCRIPTION
Due to a syntactically incorrect inline function, the string "Array" was passed to the template instead of the correct key/value combination.
