### PR TITLE
Needle/haystack order of strpos()

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend.php
+++ b/system/modules/isotope/library/Isotope/Frontend.php
@@ -690,7 +690,7 @@ window.addEvent('domready', function()
         // Payment method "Payone"
         $strParam = \Input::post('param');
 
-        if (strpos('paymentMethodPayone', $strParam) !== false) {
+        if (strpos($strParam, 'paymentMethodPayone') !== false) {
             $intId = (int) str_replace('paymentMethodPayone', '', $strParam);
             $objPostsale->setModule('pay');
             $objPostsale->setModuleId($intId);


### PR DESCRIPTION
According to [documentation](http://php.net/strpos) the parameters have to appear the other way around, else the call will always return false.
