### PR TITLE
Add post-processing hooks

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection.php
@@ -952,11 +952,13 @@ abstract class ProductCollection extends TypeAgent
             return false;
         }
 
+        $objItem = $arrItems[$intId];
+
         // !HOOK: additional functionality when a product is removed from the collection
         if (isset($GLOBALS['ISO_HOOKS']['deleteItemFromCollection']) && is_array($GLOBALS['ISO_HOOKS']['deleteItemFromCollection'])) {
             foreach ($GLOBALS['ISO_HOOKS']['deleteItemFromCollection'] as $callback) {
                 $objCallback = \System::importStatic($callback[0]);
-                $blnRemove   = $objCallback->$callback[1]($arrItems[$intId], $this);
+                $blnRemove   = $objCallback->$callback[1]($objItem, $this);
 
                 if ($blnRemove === false) {
                     return false;
@@ -964,11 +966,19 @@ abstract class ProductCollection extends TypeAgent
             }
         }
 
-        $arrItems[$intId]->delete();
+        $objItem->delete();
 
         unset($this->arrItems[$intId]);
 
         $this->tstamp = time();
+
+        // !HOOK: additional functionality when adding product to collection
+        if (isset($GLOBALS['ISO_HOOKS']['postDeleteItemFromCollection']) && is_array($GLOBALS['ISO_HOOKS']['postDeleteItemFromCollection'])) {
+            foreach ($GLOBALS['ISO_HOOKS']['postDeleteItemFromCollection'] as $callback) {
+                $objCallback = \System::importStatic($callback[0]);
+                $objCallback->$callback[1]($objItem, $this);
+            }
+        }
 
         return true;
     }


### PR DESCRIPTION
Add `postAddProductToCollection`, `postUpdateItemInCollection`, `postDeleteItemFromCollection` hooks to the product collection. I need this hooks because I need to check and manipulate the collection after the collection changed.
