### PR TITLE
Make product options available in calculatePrice Hook

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -302,6 +302,7 @@ class Standard extends Product implements IsotopeProduct, WeightAggregate
             $this->objPrice = ProductPrice::findByProductAndCollection($this, $objCollection);
         }
 
+        $this->objPrice->arrOptions = $this->arrOptions;
         return $this->objPrice;
     }
 

--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionItem.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionItem.php
@@ -151,6 +151,7 @@ class ProductCollectionItem extends \Model
             $this->objProduct = $strClass::findByPk($this->product_id);
         }
 
+        $this->objProduct->arrOptions = deserialize($this->options);
         return $this->objProduct;
     }
 


### PR DESCRIPTION
If you open the cart, the product options aren't available in the calculatePrice Hook. The Changes of commit f201c1f (#1000) make no sense for me.
