### PR TITLE
Show coupon input field, even if all available codes are used.

### DIFF
--- a/system/modules/isotope_rules/library/Isotope/Rules.php
+++ b/system/modules/isotope_rules/library/Isotope/Rules.php
@@ -223,7 +223,7 @@ class Rules extends \Controller
 
         $objRules = Rule::findForCartWithCoupons();
 
-        if (null === $objRules || !count(array_diff($objRules->fetchEach('code'), $arrCoupons))) {
+        if (null === $objRules) {
             return '';
         }
 


### PR DESCRIPTION
(1) The shop should not publicy leak if all available codes are used by the user.
(2) The message "coupon was added" will never be shown if the last available coupon was added.
