### PR TITLE
List of rules: wrong key "label" in DCA

### DIFF
--- a/system/modules/isotope_rules/dca/tl_iso_rule.php
+++ b/system/modules/isotope_rules/dca/tl_iso_rule.php
@@ -47,7 +47,7 @@ $GLOBALS['TL_DCA']['tl_iso_rule'] = array
         'label'      => array
         (
             'fields'                        => array('name', 'code'),
-            'label'                         => '%s <span style="color:#b3b3b3; padding-left:3px;">[%s]</span>',
+            'format'                         => '%s <span style="color:#b3b3b3; padding-left:3px;">[%s]</span>',
         ),
         'global_operations' => array
         (


### PR DESCRIPTION
I assume that the key `label` should be `format` in order to format the label string.
