### PR TITLE
Respect shipping exempt when calculating weight

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection.php
@@ -1222,7 +1222,7 @@ abstract class ProductCollection extends TypeAgent
      *
      * @return Scale
      */
-    public function addToScale(Scale $objScale = null)
+    public function addToScale(Scale $objScale = null, $blnForShipping = false)
     {
         if (null === $objScale) {
             $objScale = new Scale();
@@ -1234,6 +1234,10 @@ abstract class ProductCollection extends TypeAgent
             }
 
             $objProduct = $objItem->getProduct();
+
+            if ($blnForShipping && $objProduct->shipping_exempt) {
+                continue;
+            }
 
             if ($objProduct instanceof WeightAggregate) {
                 $objWeight = $objProduct->getWeight();

--- a/system/modules/isotope/library/Isotope/Model/Shipping.php
+++ b/system/modules/isotope/library/Isotope/Model/Shipping.php
@@ -100,7 +100,7 @@ abstract class Shipping extends TypeAgent
             return false;
         }
 
-        $objScale = Isotope::getCart()->addToScale();
+        $objScale = Isotope::getCart()->addToScale(null, true);
 
         if (($minWeight = Weight::createFromTimePeriod($this->minimum_weight)) !== null && $objScale->isLessThan($minWeight)) {
             return false;


### PR DESCRIPTION
Otherwise the weight exclusion of shipping modules will not be correct for products that are exempted from shipping.