### PR TITLE
PayPal::processPostsale

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
@@ -77,12 +77,9 @@ class Paypal extends Postsale implements IsotopePayment
             $arrPayment = deserialize($objOrder->payment_data, true);
             $arrPayment['POSTSALE'][] = $_POST;
             $objOrder->payment_data = $arrPayment;
-            $objOrder->save();
 
             $objOrder->date_paid = time();
             $objOrder->updateOrderStatus($this->new_order_status);
-
-            $objOrder->payment_data = $arrPayment;
 
             $objOrder->save();
 


### PR DESCRIPTION
Prüfung ob payment_status "Completed" ist, bevor eine weitere Validierung stattfindet, da diese an einen abweichenden payment_status angepasst werden müsste.

Response ist bereits in der postsale.php standardmäßig vorgesehen.