### PR TITLE
Product Group edit for non admin users

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Group/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/Group/Callback.php
@@ -102,7 +102,8 @@ class Callback extends Permission
             case 'copy':
             case 'delete':
             case 'show':
-                if (!in_array(\Input::get('id'), $root)
+            case 'cut':    
+                if (!in_array(\Input::get('id'), $user->iso_groups)
                     || (
                         \Input::get('act') == 'delete'
                         && !$user->hasAccess('delete', 'iso_groupp')


### PR DESCRIPTION
Please consider this change. Non admin users can not move or delete product group even though these functions are assigned to their users group.

![screen shot 2016-03-02 at 14 17 45](https://cloud.githubusercontent.com/assets/683894/13461433/95b09eb8-e081-11e5-9e5e-dc7daa7d8ede.png)
