### PR TITLE
Fix the wrong initial alias generation after product is duplicated

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Product/Alias.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Alias.php
@@ -30,7 +30,7 @@ class Alias extends \Backend
         // Generate alias if there is none
         if ('' === $varValue) {
             $autoAlias = true;
-            $act       = \Input::get('mode');
+            $act       = \Input::get('act');
 
             if ('edit' === $act || 'overrideAll' === $act) {
                 $varValue = (string) (\Input::post('name') ?: \Input::post('sku'));


### PR DESCRIPTION
Fixes #1659

This must have either been mistake from the very beginning or I did not get something. The ```mode``` $_GET parameter is used only for clipboard in Contao.