### PR TITLE
Fixed limiting the page picker if the product category filter is active

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php
@@ -232,6 +232,10 @@ class DcaManager extends \Backend
      */
     public function addBreadcrumb()
     {
+        if (\Input::get('table') === 'tl_iso_product') {
+            return;
+        }
+
         $strBreadcrumb = Breadcrumb::generate(\Session::getInstance()->get('iso_products_gid'));
         $strBreadcrumb .= static::getPagesBreadcrumb();
 

--- a/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php
@@ -232,7 +232,8 @@ class DcaManager extends \Backend
      */
     public function addBreadcrumb()
     {
-        if (\Input::get('table') === 'tl_iso_product') {
+        // Avoid the page node trap (#1701)
+        if (defined('TL_SCRIPT') && TL_SCRIPT === 'contao/page.php') {
             return;
         }
 


### PR DESCRIPTION
**How to reproduce**
1. Limit the backend ```Product management``` view to certain page (via ```Pages``` button in top left corner)
2. Edit the product
3. Click the ```Change selection``` button

**Problem**
The page tree in the picker is limited (```root```) to what have been chosen in the pages filter.

**Solution**
Do not run the breadcrumb function which sets the ```root``` of ```tl_page``` if in the popup.