### PR TITLE
Produktlisten-Modul: Zusätzliche Kategorien-Option

### DIFF
--- a/system/modules/isotope/dca/tl_module.php
+++ b/system/modules/isotope/dca/tl_module.php
@@ -359,7 +359,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['iso_category_scope'] = array
     'exclude'                   => true,
     'inputType'                 => 'radio',
     'default'                   => 'current_category',
-    'options'                   => array('current_category', 'current_and_first_child', 'current_and_all_children', 'parent', 'product', 'article', 'global'),
+    'options'                   => array('current_category', 'current_and_first_child', 'current_and_all_children', 'parent', 'parent_and_all_parent_children', 'product', 'article', 'global'),
     'reference'                 => &$GLOBALS['TL_LANG']['tl_module']['iso_category_scope_ref'],
     'eval'                      => array('tl_class'=>'clr w50 w50h', 'helpwizard'=>true),
     'sql'                       => "varchar(64) NOT NULL default ''",

--- a/system/modules/isotope/dca/tl_module.php
+++ b/system/modules/isotope/dca/tl_module.php
@@ -359,7 +359,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['iso_category_scope'] = array
     'exclude'                   => true,
     'inputType'                 => 'radio',
     'default'                   => 'current_category',
-    'options'                   => array('current_category', 'current_and_first_child', 'current_and_all_children', 'parent', 'parent_and_all_parent_children', 'product', 'article', 'global'),
+    'options'                   => array('current_category', 'current_and_first_child', 'current_and_all_children', 'parent', 'parent_and_siblings', 'product', 'article', 'global'),
     'reference'                 => &$GLOBALS['TL_LANG']['tl_module']['iso_category_scope_ref'],
     'eval'                      => array('tl_class'=>'clr w50 w50h', 'helpwizard'=>true),
     'sql'                       => "varchar(64) NOT NULL default ''",

--- a/system/modules/isotope/library/Isotope/Module/Module.php
+++ b/system/modules/isotope/library/Isotope/Module/Module.php
@@ -163,6 +163,11 @@ abstract class Module extends AbstractFrontendModule
                     $arrCategories = [$objPage->pid];
                     break;
 
+                case 'parent_and_all_parent_children':
+                    $arrCategories = [$objPage->pid];
+                    $arrCategories = \Database::getInstance()->getChildRecords($objPage->pid, 'tl_page', false, $arrCategories, $strWhere);
+                    break;
+
                 case 'product':
                     /** @var \Isotope\Model\Product\Standard $objProduct */
                     $objProduct = Product::findAvailableByIdOrAlias(Input::getAutoItem('product'));

--- a/system/modules/isotope/library/Isotope/Module/Module.php
+++ b/system/modules/isotope/library/Isotope/Module/Module.php
@@ -163,7 +163,7 @@ abstract class Module extends AbstractFrontendModule
                     $arrCategories = [$objPage->pid];
                     break;
 
-                case 'parent_and_all_parent_children':
+                case 'parent_and_siblings':
                     $arrCategories = [$objPage->pid];
                     $arrCategories = \Database::getInstance()->getChildRecords($objPage->pid, 'tl_page', false, $arrCategories, $strWhere);
                     break;


### PR DESCRIPTION
Das Pull-Request fügt im Isotope Produktlisten-Modul bei der Kategorien-Auswahl die Option hinzu, alle Produkte der Eltern-Kategorie mit allen Geschwister-Kategorien anzuzeigen.

Dies benötigt man z.B. falls man die Elternkategorie mit einer SQL-Bedingung noch verfeinern möchte.

Es fehlen noch die entsprechenden Übersetzungen.