### PR TITLE
fix for #1833

### DIFF
--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -166,20 +166,14 @@ class PostSale extends \Frontend
             $objResponse->send();
 
         } catch (\Exception $e) {
-            \System::log(
-                sprintf(
-                    'Exception in post-sale request. See system/logs/isotope_postsale.log for details.',
-                    $e->getFile(),
-                    $e->getLine(),
-                    $e->getMessage()
-                ),
-                __METHOD__,
-                TL_ERROR
-            );
+            \System::log('Exception in post-sale request. See system/logs/isotope_postsale.log for details.', __METHOD__, TL_ERROR);
 
             log_message(
                 sprintf(
-                    "Exception in post-sale request\n%s\n\n",
+                    "Exception in post-sale request\n%s(%s): %s\n%s\n\n",
+                    $e->getFile(),
+                    $e->getLine(),
+                    $e->getMessage(),
                     $e->getTraceAsString()
                 ),
                 'isotope_postsale.log'


### PR DESCRIPTION
This will log exceptions like so:
```
[31-Jul-2017 13:55:14] Exception in post-sale request
…/vendor/codefog/contao-haste/library/Haste/Http/Response/Response.php(259): This exception has no message. Use $exception->getResponse() instead.
#0 …/vendor/isotope/isotope-core/system/modules/isotope/postsale.php(166): Haste\Http\Response\Response->send()
#1 …/vendor/isotope/isotope-core/system/modules/isotope/postsale.php(234): Isotope\PostSale->run()
#2 {main}
```
instead of just
```
[31-Jul-2017 13:55:14] Exception in post-sale request
#0 …/vendor/isotope/isotope-core/system/modules/isotope/postsale.php(166): Haste\Http\Response\Response->send()
#1 …/vendor/isotope/isotope-core/system/modules/isotope/postsale.php(234): Isotope\PostSale->run()
#2 {main}
```
See #1833 