### PR TITLE
Output actual exception message in postsale

### DIFF
--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -167,24 +167,12 @@ class PostSale extends \Frontend
 
         } catch (\Exception $e) {
             \System::log(
-                sprintf(
-                    'Exception in post-sale request. See system/logs/isotope_postsale.log for details.',
-                    $e->getFile(),
-                    $e->getLine(),
-                    $e->getMessage()
-                ),
+                'Exception in post-sale request. See system/logs/isotope_postsale.log for details.',
                 __METHOD__,
                 TL_ERROR
             );
 
-            log_message(
-                sprintf(
-                    "Exception in post-sale request\n%s\n%s\n\n",
-                    $e->getMessage(),
-                    $e->getTraceAsString()
-                ),
-                'isotope_postsale.log'
-            );
+            log_message((string) $e, 'isotope_postsale.log');
 
             $objResponse = new Response('Internal Server Error', 500);
             $objResponse->send();

--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -179,7 +179,8 @@ class PostSale extends \Frontend
 
             log_message(
                 sprintf(
-                    "Exception in post-sale request\n%s\n\n",
+                    "Exception in post-sale request\n%s\n%s\n\n",
+                    $e->getMessage(),
                     $e->getTraceAsString()
                 ),
                 'isotope_postsale.log'


### PR DESCRIPTION
I thought, the actual exception message would be helpful for debugging.
Just now, I have the stack trace, but not the resulting exception message.

For example, this is the output in my postsale log:
```
[02-Aug-2017 22:02:30] Exception in post-sale request
#0 /opt/users/www/system/modules/core/library/Contao/Database.php(207): Contao\Database\Statement->query('SELECT id, name...')
#1 /opt/users/www/composer/vendor/codefog/contao-haste/library/Haste/Util/Format.php(149): Contao\Database->query('SELECT id, name...')
#2 /opt/users/www/composer/vendor/codefog/contao-haste/library/Haste/Util/Format.php(123): Haste\Util\Format::dcaValueFromArray(Array, NULL, NULL)
#3 /opt/users/www/system/modules/cfg_isotope_stock_management/src/Entry/AbstractEntry.php(121): Haste\Util\Format::dcaValue('tl_iso_product', 'groups', NULL)
#4 /opt/users/www/system/modules/cfg_isotope_stock_management/src/Entry/AbstractEntry.php(97): Codefog\IsotopeStockManagement\Entry\AbstractEntry->sendOutOfStockNotification()
#5 /opt/users/www/system/modules/cfg_isotope_stock_management/src/Hooks.php(132): Codefog\IsotopeStockManagement\Entry\AbstractEntry->save()
#6 /opt/users/www/composer/vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php(186): Codefog\IsotopeStockManagement\Hooks->postCheckout(Object(Isotope\Model\ProductCollection\Order), Array)
#7 /opt/users/www/composer/vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php(74): Isotope\Model\ProductCollection\Order->checkout()
#8 /opt/users/www/system/modules/isotope/postsale.php(178): Isotope\Model\Payment\Paypal->processPostsale(Object(Isotope\Model\ProductCollection\Order))
#9 /opt/users/www/system/modules/isotope/postsale.php(240): Isotope\PostSale->run()
#10 {main}
```