### PR TITLE
Fix for broken cumulative filter when using foreign key attributes

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Attribute/AbstractAttributeWithOptions.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/AbstractAttributeWithOptions.php
@@ -251,7 +251,8 @@ abstract class AbstractAttributeWithOptions extends Attribute implements Isotope
                 return $arrOptions;
 
             case IsotopeAttributeWithOptions::SOURCE_FOREIGNKEY:
-                list($table, $field) = explode('.', $this->foreignKey, 2);
+                $foreignKey = $this->parseForeignKey($this->foreignKey, $GLOBALS['TL_LANGUAGE']);
+                list($table, $field) = explode('.', $foreignKey, 2);
                 $result = \Database::getInstance()->execute("
                     SELECT id AS value, $field AS label
                     FROM $table


### PR DESCRIPTION
Wird ein Attribut Für Varianten genutzt und als Attribut Optionen-Quelle "foreignKey" gewählt, so kommt es zu einem SQL Error beim CumulativeFilter wenn Mehrsprachigkeit nach dem vorausgesetzten Schema (z.B. de=table.field) angegeben wird.

> [14-Aug-2017 12:37:32 Europe/Zurich] PHP Fatal error: Uncaught exception 'Exception' with message 'Query error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '=mm_product_color_group.nameEn
fr=mm_product_color_group.nameFr AS label
       ' at line 2 (SELECT id AS value, nameDe
en=mm_product_color_group.nameEn
fr=mm_product_color_group.nameFr AS label
                    FROM de=mm_product_color_group
                    WHERE id IN (4,3,1,5,2))' thrown in ...../system/modules/core/library/Contao/Database/Statement.php on line 295

Problem und Fix sind das Gleiche wie hier
https://github.com/isotope/core/commit/b2fae7734ee6e2c2b763a261528f8a4ff5e8dbeb