### PR TITLE
Fix Saferpay PSP URL check

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Payment/Saferpay.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Saferpay.php
@@ -119,11 +119,16 @@ class Saferpay extends Postsale implements IsotopeOrderStatusAware
         $objRequest->setHeader('Content-Type', 'application/x-www-form-urlencoded');
         $objRequest->send(static::createPayInitURI, http_build_query($this->generatePaymentPostData($objOrder), null, '&'), 'POST');
 
-        if ((int) $objRequest->code !== 200 || 0 !== strpos($objRequest->response, 'ERROR:')) {
+        if ((int) $objRequest->code !== 200 || 0 === strpos($objRequest->response, 'ERROR:')) {
             \System::log(sprintf('Could not get the redirect URI from Saferpay. See log files for further details.'), __METHOD__, TL_ERROR);
             log_message(sprintf('Could not get the redirect URI from Saferpay. Response was: "%s".', $objRequest->response), 'isotope_saferpay.log');
 
             Checkout::redirectToStep('failed');
+        }
+
+        // redirect immediately
+        if (\Contao\Validator::isUrl($objRequest->response)) {
+            \Controller::redirect($objRequest->response);
         }
 
         $GLOBALS['TL_HEAD'][] = '<meta http-equiv="refresh" content="1; URL=' . $objRequest->response . '">';


### PR DESCRIPTION
Fix for #1855   
The check for a valid Saferpay redirect URL was broken. A valid URL was validated as false and so the payment process failed.