### PR TITLE
fix symlink command for Windows

### DIFF
--- a/system/modules/isotope/library/Isotope/ContaoManager/Plugin.php
+++ b/system/modules/isotope/library/Isotope/ContaoManager/Plugin.php
@@ -18,7 +18,7 @@ class Plugin implements ConfigPluginInterface
             $container->setDefinition(
                 'isotope.listener.console',
                 (new Definition('Isotope\EventListener\SymlinkCommandListener'))
-                    ->setArguments(['%kernel.project_dir%'])
+                    ->setArguments(['%kernel.root_dir%'])
                     ->addTag('kernel.event_listener', ['event' => 'console.terminate'])
             );
         });

--- a/system/modules/isotope/library/Isotope/ContaoManager/Plugin.php
+++ b/system/modules/isotope/library/Isotope/ContaoManager/Plugin.php
@@ -18,7 +18,7 @@ class Plugin implements ConfigPluginInterface
             $container->setDefinition(
                 'isotope.listener.console',
                 (new Definition('Isotope\EventListener\SymlinkCommandListener'))
-                    ->setArguments(['%kernel.root_dir%'])
+                    ->setArguments(['%kernel.project_dir%'])
                     ->addTag('kernel.event_listener', ['event' => 'console.terminate'])
             );
         });

--- a/system/modules/isotope/library/Isotope/EventListener/SymlinkCommandListener.php
+++ b/system/modules/isotope/library/Isotope/EventListener/SymlinkCommandListener.php
@@ -21,7 +21,7 @@ class SymlinkCommandListener
      */
     public function __construct($rootDir)
     {
-        $this->rootDir = $rootDir;
+        $this->rootDir = dirname($rootDir);
     }
 
     /**

--- a/system/modules/isotope/library/Isotope/EventListener/SymlinkCommandListener.php
+++ b/system/modules/isotope/library/Isotope/EventListener/SymlinkCommandListener.php
@@ -3,6 +3,7 @@
 namespace Isotope\EventListener;
 
 use Contao\CoreBundle\Command\SymlinksCommand;
+use Contao\CoreBundle\Util\SymlinkUtil;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -24,7 +25,7 @@ class SymlinkCommandListener
     }
 
     /**
-     * Adds the initialize.php file.
+     * Adds the isotope symlink.
      *
      * @param ConsoleTerminateEvent $event
      */
@@ -34,8 +35,8 @@ class SymlinkCommandListener
             return;
         }
 
-        (new Filesystem())
-            ->symlink('../isotope', $this->rootDir.'/../web/isotope')
-        ;
+        (new Filesystem())->mkdir($this->rootDir . '/isotope');
+
+        SymlinkUtil::symlink('isotope', 'web/isotope', $this->rootDir);
     }
 }


### PR DESCRIPTION
This PR actually fixes three things:

* Fixes a copy & paste error in the comments.
* Fixes an error if the `/isotope` folder was not already present before updating.
* Fixes the symlink generation under Windows by using `Contao\CoreBundle\Util\SymlinkUtil` instead.

See also https://github.com/isotope/core/issues/1794#issuecomment-347970250