### PR TITLE
Fixed the Isotope backend icon in Contao 4.4+

### DIFF
--- a/system/modules/isotope/assets/css/backend-contao4.css
+++ b/system/modules/isotope/assets/css/backend-contao4.css
@@ -1,0 +1,4 @@
+#tl_navigation .tl_level_1_group .group-isotope {
+    background: url(../images/module44.svg) 5px 1px no-repeat;
+    background-size: 14px 14px;
+}

--- a/system/modules/isotope/assets/css/backend.css
+++ b/system/modules/isotope/assets/css/backend.css
@@ -4,11 +4,6 @@
     background-size: 16px 16px;
 }
 
-body.iso_backend44 #tl_navigation .tl_level_1_group .group-isotope {
-    background: url(../images/module44.svg) 5px 1px no-repeat;
-    background-size: 14px 14px;
-}
-
 .header_import_assets
 {
     padding:2px 0 3px 20px;

--- a/system/modules/isotope/config/config.php
+++ b/system/modules/isotope/config/config.php
@@ -55,6 +55,10 @@ if ('BE' === TL_MODE) {
     if (file_exists(TL_ROOT . '/system/themes/flexible/icons')) {
         $GLOBALS['TL_CSS'][] = 'system/modules/isotope/assets/css/backend-svg.css|static';
     }
+
+    if (version_compare(VERSION, '4.4', '>=')) {
+        $GLOBALS['TL_CSS'][] = 'system/modules/isotope/assets/css/backend-contao4.css|static';
+    }
 }
 
 


### PR DESCRIPTION
Fixes #1911. A similar fix was implemented in notification_center https://github.com/terminal42/contao-notification_center/commit/0ecc1ec1fee6ad225ffbb4ee363b006ced499a7b