### PR TITLE
Check for a non-null product type.

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend.php
+++ b/system/modules/isotope/library/Isotope/Frontend.php
@@ -657,7 +657,9 @@ class Frontend extends \Frontend
     {
         $fltAmount = $fltPrice;
 
-        if ($objSource instanceof IsotopePrice && ($objProduct = $objSource->getRelated('pid')) !== null) {
+        if ($objSource instanceof IsotopePrice
+            && ($objProduct = $objSource->getRelated('pid')) instanceof IsotopeProduct
+            && $objProduct->getType() !== null) {
             /** @var IsotopeProduct|Standard $objProduct */
 
             $arrAttributes = array_intersect(


### PR DESCRIPTION
The product type can be null as of the API. See https://github.com/isotope/core/blob/master/system/modules/isotope/library/Isotope/Interfaces/IsotopeProduct.php#L46