### PR TITLE
hotfix change AbstractButton to use own button template

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend/ProductAction/AbstractButton.php
+++ b/system/modules/isotope/library/Isotope/Frontend/ProductAction/AbstractButton.php
@@ -3,6 +3,7 @@
 namespace Isotope\Frontend\ProductAction;
 
 use Isotope\Interfaces\IsotopeProduct;
+use Isotope\Template;
 
 abstract class AbstractButton implements ProductActionInterface
 {
@@ -19,13 +20,14 @@ abstract class AbstractButton implements ProductActionInterface
      */
     public function generate(IsotopeProduct $product, array $config = [])
     {
-        return sprintf(
-            '<input type="submit" name="%s" class="submit %s %s" value="%s">',
-            $this->getName(),
-            $this->getName(),
-            $this->getClasses($product),
-            $this->getLabel($product)
-        );
+        /** @var Template|\stdClass $objTemplate */
+        $objTemplate = new Template('iso_button');
+
+        $objTemplate->name    = $this->getName();
+        $objTemplate->classes = $this->getClasses($product);
+        $objTemplate->label   = $this->getLabel($product);
+
+        return $objTemplate->parse();
     }
 
     /**

--- a/system/modules/isotope/library/Isotope/Frontend/ProductCollectionAction/AbstractButton.php
+++ b/system/modules/isotope/library/Isotope/Frontend/ProductCollectionAction/AbstractButton.php
@@ -3,6 +3,7 @@
 namespace Isotope\Frontend\ProductCollectionAction;
 
 use Isotope\Interfaces\IsotopeProductCollection;
+use Isotope\Template;
 
 abstract class AbstractButton implements ProductCollectionActionInterface
 {
@@ -19,12 +20,14 @@ abstract class AbstractButton implements ProductCollectionActionInterface
      */
     public function generate(IsotopeProductCollection $collection)
     {
-        return sprintf(
-            '<input type="submit" name="button_%s" class="submit %s" value="%s">',
-            $this->getName(),
-            $this->getName(),
-            $this->getLabel($collection)
-        );
+        /** @var Template|\stdClass $objTemplate */
+        $objTemplate = new Template('iso_button');
+
+        $objTemplate->name    = 'button_' . $this->getName();
+        $objTemplate->classes = $this->getName();
+        $objTemplate->label   = $this->getLabel($collection);
+
+        return $objTemplate->parse();
     }
 
     /**

--- a/system/modules/isotope/templates/isotope/iso_button.html5
+++ b/system/modules/isotope/templates/isotope/iso_button.html5
@@ -1,0 +1,1 @@
+<input type="submit" name="<?= $this->name ?>" class="submit <?= $this->name ?> <?= $this->classes ?>" value="<?= $this->label ?>">


### PR DESCRIPTION
hotfix change AbstractButton to use own button template e.g. bootstrap like

```
<?php
$icon         = '';
$iconTemplate = '<span class="oi oi-%s" aria-hidden="true" role="button"></span> ';

switch ($this->name) {
    case 'update':
        $icon = sprintf($iconTemplate, 'loop-circular');
        break;
    case 'add_to_cart':
        $icon = sprintf($iconTemplate, 'cart');
        break;
}
?>
<button type="submit" name="<?= $this->name ?>" class="submit <?= $this->name ?> <?= $this->classes ?> btn btn-primary btn-sm" value="<?= $this->label ?>"><?= $icon ?><?= $this->label ?></button>
```