### PR TITLE
Fix the condition for product type based shipping calculation.

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Shipping/Flat.php
+++ b/system/modules/isotope/library/Isotope/Model/Shipping/Flat.php
@@ -54,7 +54,7 @@ class Flat extends Shipping
                     $allowedTypes = deserialize($this->product_types);
                     $productType  = $objItem->getProduct()->getType();
 
-                    if (is_array($allowedTypes) || !in_array($productType->id, $allowedTypes, false)) {
+                    if (\is_array($allowedTypes) && !\in_array($productType->id, $allowedTypes, false)) {
                         continue;
                     }
                 }


### PR DESCRIPTION
Hallo,

dies ist ein Fix, damit das Vorhaben in #1970 gelingt.

Es handelt sich um die Einstellung "Preis für diese Produkttypen berechnen" bei den Versandarten.

<img width="354" alt="screen shot 2018-09-06 at 09 46 12" src="https://user-images.githubusercontent.com/1284725/45142797-b7789800-b1b9-11e8-8117-a8fa45e7f019.png">

Ich habe mir den Code angeschaut und deshalb habe ich von dieser Einstellung erwartet, in der Preisberechnung **nur die Produkte mit zutreffendem Produkttyp zu berücksichtigen**.

Allerdings war ein Vorzeichen falsch.

Die betroffene Stelle wurde das letze mal in https://github.com/isotope/core/commit/25aa89b914097073d57b11adf5bce1341d1bc924#diff-b5a411f80105f8e2809e6e9f24529307 bearbeitet.

<hr>

<img width="695" alt="screen shot 2018-09-06 at 09 48 11" src="https://user-images.githubusercontent.com/1284725/45142899-00305100-b1ba-11e8-836c-df16b0501d67.png">

_Vorher:_ Diese Einstellung resultiert in Versandkosten in Höhe von **0**, auch wenn ein Produkt mit "Test-Produkttyp 1" im Warenkorb liegt.

_Nach diesem Fix:_ Diese Einstellung resultiert in Versandkosten, wie erwartet, wenn ein Produkt mit "Test-Produkttyp 1" im Warenkorb liegt.
Edit: Wie erwartet heißt, dass die Versandkosten nur Anwendung finden, für diesen Produkttyp, und ignoriert wird, für andere Produkktypen. Details siehe #1970.