### PR TITLE
remove Theme.focusInput

### DIFF
--- a/system/modules/isotope/drivers/DC_ProductData.php
+++ b/system/modules/isotope/drivers/DC_ProductData.php
@@ -697,13 +697,7 @@ class DC_ProductData extends \DC_Table
 </div>
 
 </div>
-</form>
-
-<script>
-  window.addEvent(\'domready\', function() {
-    Theme.focusInput("'.$this->strTable.'");
-  });
-</script>';
+</form>';
 
         $copyFallback = $this->blnEditLanguage ? '&nbsp;&nbsp;::&nbsp;&nbsp;<a href="' . \Backend::addToUrl('act=copyFallback') . '" class="header_iso_copy" title="' . specialchars($GLOBALS['TL_LANG']['MSC']['copyFallback']) . '" accesskey="d" onclick="Backend.getScrollOffset();">' . ($GLOBALS['TL_LANG']['MSC']['copyFallback'] ? $GLOBALS['TL_LANG']['MSC']['copyFallback'] : 'copyFallback') . '</a>' : '';
 


### PR DESCRIPTION
Currently when you edit product data in the back end, the following JavaScript error happens:
```
TypeError: Theme.focusInput is not a function
```
The method `focusInput` does not exist for the `Theme` object  of the back end theme of Contao 4.4.26. It was also removed in Contao 3.5.16: https://github.com/contao/core/commit/fa28b67b6cfe2dde692fc17b34bb2c137794dd93

Therefore I think it's best to just remove it from Isotope as well?