### PR TITLE
Attribute options: Extended "foreignKey" format to support an additional sorting field

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Attribute.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute.php
@@ -247,11 +247,13 @@ abstract class Attribute extends TypeAgent implements IsotopeAttribute
 
                 case IsotopeAttributeWithOptions::SOURCE_FOREIGNKEY:
                     $foreignKey = $this->parseForeignKey($this->foreignKey, $GLOBALS['TL_LANGUAGE']);
-                    $arrKey     = explode('.', $foreignKey, 2);
+                    $table      = strtok($foreignKey, '.');
+                    $label      = strtok(',');
+                    $sorting    = strtok(null) ?: $label;
 
-                    if ('' !== (string) $arrKey[0] && '' !== $arrKey[1]) {
+                    if ('' !== (string) $table && '' !== $label) {
                         $arrOptions = \Database::getInstance()
-                            ->execute("SELECT id AS value, {$arrKey[1]} AS label FROM {$arrKey[0]} ORDER BY label")
+                            ->execute("SELECT id AS value, $label AS label FROM $table ORDER BY $sorting")
                             ->fetchAllAssoc()
                         ;
                     }


### PR DESCRIPTION
Attribute options get sorted by "label" (current behavior).

This change allows to specify an optional sorting field (default is still "label")

<img width="630" alt="screen shot 2018-12-07 at 11 11 25" src="https://user-images.githubusercontent.com/3243377/49641758-61fa9400-fa11-11e8-9633-987018cb2768.png">
