### PR TITLE
use template for buttons

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend/ProductAction/AbstractButton.php
+++ b/system/modules/isotope/library/Isotope/Frontend/ProductAction/AbstractButton.php
@@ -2,6 +2,7 @@
 
 namespace Isotope\Frontend\ProductAction;
 
+use Contao\FrontendTemplate;
 use Isotope\Interfaces\IsotopeProduct;
 
 abstract class AbstractButton implements ProductActionInterface
@@ -19,13 +20,12 @@ abstract class AbstractButton implements ProductActionInterface
      */
     public function generate(IsotopeProduct $product, array $config = [])
     {
-        return sprintf(
-            '<input type="submit" name="%s" class="submit %s %s" value="%s">',
-            $this->getName(),
-            $this->getName(),
-            $this->getClasses($product),
-            $this->getLabel($product)
-        );
+        $objTemplate = new FrontendTemplate('iso_button');
+        $objTemplate->name = $this->getName();
+        $objTemplate->class = implode(' ', ['submit', $this->getName(), $this->getClasses($product)]);
+        $objTemplate->value = $this->getLabel($product);
+
+        return $objTemplate->parse();
     }
 
     /**

--- a/system/modules/isotope/templates/isotope/iso_button.html5
+++ b/system/modules/isotope/templates/isotope/iso_button.html5
@@ -1,0 +1,2 @@
+
+<input type="submit" name="<?= $this->name ?>" class="<?= $this->class ?>" value="<?= $this->value ?>">


### PR DESCRIPTION
Currently buttons of product actions are hardcoded to be `<input>`s. This PR would allow those buttons to be changed to `<button>`s for example, if desired, by overriding the `iso_button` template.