### PR TITLE
add product type css class

### DIFF
--- a/system/modules/isotope/library/Isotope/Module/ProductReader.php
+++ b/system/modules/isotope/library/Isotope/Module/ProductReader.php
@@ -206,6 +206,11 @@ class ProductReader extends Module
             $classes[] = (string) $arrCSS[1];
         }
 
+        $objType = $objProduct->getRelated('type');
+        if (!empty($objType->cssClass)) {
+            $classes[] = $objType->cssClass;
+        }
+
         return implode(' ', $classes);
     }
 


### PR DESCRIPTION
Within the product type configuration you are able to define a CSS class:

![screenshot_2019-01-14 shop-konfiguration - contao open source cms](https://user-images.githubusercontent.com/4970961/51120008-7a31b000-1814-11e9-9285-36871912a75b.png)

According to the description, that CSS class is supposed to be added to the other product CSS classes in the product list and product reader. However, this does not actually work. The `cssClass` of the product type is actually not used anywhere currently.