### PR TITLE
fix sql cache file creation on Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "terminal42/notification_center": "~1.0",
         "terminal42/dc_multilingual": "~2.0",
         "guzzlehttp/guzzle": "~6.0",
-        "tecnickcom/tcpdf": "^6.2.22"
+        "tecnickcom/tcpdf": "^6.2.22",
+        "symfony/filesystem": "^3.4 || ^4.0"
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",

--- a/system/modules/isotope/library/Isotope/Backend/Attribute/DatabaseUpdate.php
+++ b/system/modules/isotope/library/Isotope/Backend/Attribute/DatabaseUpdate.php
@@ -74,7 +74,7 @@ class DatabaseUpdate extends \DcaExtractor
         } else {
             $file = sprintf(
                 '%s/contao/sql/%s.php',
-                str_replace(TL_ROOT.'/', '', \System::getContainer()->getParameter('kernel.cache_dir')),
+                str_replace(TL_ROOT.\DIRECTORY_SEPARATOR, '', \System::getContainer()->getParameter('kernel.cache_dir')),
                 $this->strTable
             );
         }

--- a/system/modules/isotope/library/Isotope/Backend/Attribute/DatabaseUpdate.php
+++ b/system/modules/isotope/library/Isotope/Backend/Attribute/DatabaseUpdate.php
@@ -72,9 +72,11 @@ class DatabaseUpdate extends \DcaExtractor
         if (version_compare(VERSION, '4.0', '<')) {
             $file = 'system/cache/sql/' . $this->strTable . '.php';
         } else {
+            $filesystem = new \Symfony\Component\Filesystem\Filesystem();
+            $cacheDir = \System::getContainer()->getParameter('kernel.cache_dir');
             $file = sprintf(
                 '%s/contao/sql/%s.php',
-                str_replace(TL_ROOT.\DIRECTORY_SEPARATOR, '', \System::getContainer()->getParameter('kernel.cache_dir')),
+                $filesystem->makePathRelative($cacheDir, TL_ROOT),
                 $this->strTable
             );
         }


### PR DESCRIPTION
Under Windows, the following error might occur, when creating new attributes in the shop configuration:
```
Symfony\Component\Debug\Exception\ContextErrorException:
Warning: mkdir(): No such file or directory

  at vendor\contao\core-bundle\src\Resources\contao\library\Contao\Files.php:84
  at Contao\Files->mkdir('[C:\\Users\\fritzmg\\www\\contao4]\\var\\cache\\dev')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Folder.php:93)
  at Contao\Folder->__construct('[C:\\Users\\fritzmg\\www\\contao4]\\var\\cache\\dev/contao/sql')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\File.php:560)
  at Contao\File->close()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\Attribute\DatabaseUpdate.php:99)
  at Isotope\Backend\Attribute\DatabaseUpdate->dumpCacheFile()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\Attribute\DatabaseUpdate.php:30)
  at Isotope\Backend\Attribute\DatabaseUpdate->onSubmit(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:2108)
  at Contao\DC_Table->edit()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\BackendModule\BackendOverview.php:232)
  at Isotope\BackendModule\BackendOverview->getModule('attributes')
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\BackendModule\BackendOverview.php:68)
  at Isotope\BackendModule\BackendOverview->generate()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:423)
  at Contao\Backend->getBackendModule('iso_setup', null)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:132)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:55)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\symfony\src\Symfony\Component\HttpKernel\HttpKernel.php:151)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor\symfony\symfony\src\Symfony\Component\HttpKernel\HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor\symfony\symfony\src\Symfony\Component\HttpKernel\Kernel.php:200)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web\app_dev.php:69)
```
This is because `TL_ROOT` isn't actually removed from the `kernel.cache_dir` due to the directory separator mismatch. Thus `\Contao\Files` will want to create a new directory under
```
C:\Users\fritzmg\www\contao4/C:\Users\fritzmg\www\contao4\var\cache\dev
```
which of course will not work.