### PR TITLE
Force creation of resized images to allow synchronous file access

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
@@ -11,6 +11,7 @@
 
 namespace Isotope\Model\Gallery;
 
+use Contao\File;
 use Haste\Image\Image;
 use Isotope\Interfaces\IsotopeGallery;
 use Isotope\Model\Gallery;
@@ -357,6 +358,11 @@ class Standard extends Gallery implements IsotopeGallery
         try {
             $strImage = \Image::create($strFile, $size)->executeResize()->getResizedPath();
             $picture = \Picture::create($strFile, $size)->getTemplateData();
+
+            $objResizedFile = new File($strImage);
+            if(method_exists($objResizedFile, 'createIfDeferred')) {
+                $objResizedFile->createIfDeferred();
+            }
         } catch (\Exception $e) {
             \System::log('Image "' . $strFile . '" could not be processed: ' . $e->getMessage(), __METHOD__, TL_ERROR);
 

--- a/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
@@ -365,19 +365,16 @@ class Standard extends Gallery implements IsotopeGallery
             $picture = array('img'=>array('src'=>'', 'srcset'=>''), 'sources'=>array());
         }
 
-        $objResizedFile = new File(rawurldecode($strImage));
-
         // Watermark
         if ($blnWatermark
             && $this->{$strType . '_watermark_image'} != ''
             && ($objWatermark = \FilesModel::findByUuid($this->{$strType . '_watermark_image'})) !== null
         ) {
-            if(method_exists($objResizedFile, 'createIfDeferred')) {
-                $objResizedFile->createIfDeferred();
+            if (method_exists(File::class, 'createIfDeferred')) {
+                (new File(rawurldecode($strImage)))->createIfDeferred();
             }
 
             $strImage = Image::addWatermark($strImage, $objWatermark->path, $this->{$strType . '_watermark_position'});
-            $objResizedFile = new File(rawurldecode($strImage));
 
             // Apply watermark to the picture image source
             if ($picture['img']['src']) {
@@ -390,7 +387,7 @@ class Standard extends Gallery implements IsotopeGallery
             }
         }
 
-        $arrSize = $objResizedFile->imageSize;
+        $arrSize = (new File(rawurldecode($strImage)))->imageSize;
 
         if (\is_array($arrSize) && $arrSize[3] !== '') {
             $arrFile[$strType . '_size']      = $arrSize[3];


### PR DESCRIPTION
Isotope triggers image resizing like this...

```php
$strImage = \Image::create($strFile, $size)->executeResize()->getResizedPath();
```

...but then, the returned path is directly used in file access calls like so:

https://github.com/isotope/core/blob/348a59524b3d599cdc0fb728515d3ad075cbe782/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php#L385

This cannot work with deferred image resizing in Contao >= 4.8. The easiest fix would probably be to execute the resizing synchronously (see this PR). This is possible with https://github.com/contao/contao/pull/693 which was implemented to deal with the same situation in the Contao newsletter (where synchronous access is also neccessary).