### PR TITLE
Fixes some MySQL 8 Exceptions

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCache.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCache.php
@@ -76,7 +76,7 @@ class ProductCache extends \Model
                 'uniqid=?',
                 "(keywords=? OR keywords='')",
                 '(expires>? OR expires=0)',
-                'groups=?'
+                'tl_iso_productcache.groups=?'
             ),
             array(
                 $uniqid,
@@ -122,7 +122,7 @@ class ProductCache extends \Model
         \Database::getInstance()->prepare("
             DELETE FROM tl_iso_productcache
             WHERE
-                (uniqid=? AND groups=? AND (keywords='' OR keywords=?))
+                (uniqid=? AND tl_iso_productcache.groups=? AND (keywords='' OR keywords=?))
                 OR (expires>0 AND expires<$time)
         ")->execute(
             $uniqid,
@@ -209,7 +209,7 @@ class ProductCache extends \Model
         \Database::getInstance()->prepare("
             DELETE FROM tl_iso_productcache
             WHERE
-                (page_id=? AND module_id=? AND requestcache_id=? AND keywords=? AND groups=?)
+                (page_id=? AND module_id=? AND requestcache_id=? AND keywords=? AND tl_iso_productcache.groups=?)
                 OR (expires>0 AND expires<$time)
         ")->execute(
             $intPage,


### PR DESCRIPTION
Got this error in the contao logs:
```
[2019-10-24 18:22:40] app.CRITICAL: An exception occurred. {"exception":"[object] (Doctrine\\DBAL\\Exception\\SyntaxErrorException(code: 0): An exception occurred while executing 'SELECT tl_iso_productcache.* FROM tl_iso_productcache WHERE uniqid='[anonymized-id]' AND (keywords='' OR keywords='') AND (expires>1571934160 OR expires=0) AND groups='' LIMIT 0,1':\n\nSQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups='' LIMIT 0,1' at line 1 at [anonymized]/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:99, Doctrine\\DBAL\\Driver\\PDOException(code: 42000): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups='' LIMIT 0,1' at line 1 at [anonymized]/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:109, PDOException(code: 42000): SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups='' LIMIT 0,1' at line 1 at [anonymized]/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:107)"} []
```
Maybe my modification is a "dirty hack" but it works with MySQL 8 and the website is loading without any errors.