### PR TITLE
Support new rootfallback palette

### DIFF
--- a/system/modules/isotope/dca/tl_page.php
+++ b/system/modules/isotope/dca/tl_page.php
@@ -23,12 +23,14 @@ $GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'][] = function(\DataCon
 /**
  * Extend tl_page palettes
  */
-\Haste\Dca\PaletteManipulator::create()
-    ->addLegend('isotope_legend', 'publish_legen', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)
-    ->addField('iso_config', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
-    ->addField('iso_store_id', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
-    ->applyToPalette('root', 'tl_page')
-;
+try {
+    \Haste\Dca\PaletteManipulator::create()
+        ->addLegend('isotope_legend', 'publish_legen', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)
+        ->addField('iso_config', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
+        ->addField('iso_store_id', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
+        ->applyToPalette('root', 'tl_page')
+        ->applyToPalette('rootfallback', 'tl_page');
+} catch (\InvalidArgumentException $e) {}
 
 \Haste\Dca\PaletteManipulator::create()
     ->addLegend('isotope_legend', 'publish_legen', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)

--- a/system/modules/isotope/dca/tl_page.php
+++ b/system/modules/isotope/dca/tl_page.php
@@ -33,7 +33,7 @@ try {
 } catch (\InvalidArgumentException $e) {}
 
 \Haste\Dca\PaletteManipulator::create()
-    ->addLegend('isotope_legend', 'publish_legen', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)
+    ->addLegend('isotope_legend', 'publish_legend', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)
     ->addField('iso_setReaderJumpTo', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
     ->applyToPalette('regular', 'tl_page')
 ;

--- a/system/modules/isotope/dca/tl_page.php
+++ b/system/modules/isotope/dca/tl_page.php
@@ -25,7 +25,7 @@ $GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'][] = function(\DataCon
  */
 try {
     \Haste\Dca\PaletteManipulator::create()
-        ->addLegend('isotope_legend', 'publish_legen', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)
+        ->addLegend('isotope_legend', 'publish_legend', \Haste\Dca\PaletteManipulator::POSITION_BEFORE)
         ->addField('iso_config', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
         ->addField('iso_store_id', 'isotope_legend', \Haste\Dca\PaletteManipulator::POSITION_APPEND)
         ->applyToPalette('root', 'tl_page')


### PR DESCRIPTION
The second `applyToPalette` will throw an exception in Contao <4.9, that's why there is an try-catch-clause