### PR TITLE
Set constant FE_USER_LOGGED_IN

### DIFF
--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -28,6 +28,7 @@ use Haste\Http\Response\Response;
  */
 \define('TL_MODE', 'FE');
 \define('BYPASS_TOKEN_CHECK', true);
+\define('FE_USER_LOGGED_IN', false);
 
 require_once('initialize.php');
 

--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -28,7 +28,6 @@ use Haste\Http\Response\Response;
  */
 \define('TL_MODE', 'FE');
 \define('BYPASS_TOKEN_CHECK', true);
-\define('FE_USER_LOGGED_IN', false);
 
 require_once('initialize.php');
 
@@ -53,6 +52,8 @@ class PostSale extends \Frontend
     public function __construct()
     {
         parent::__construct();
+        
+        \define('FE_USER_LOGGED_IN', false);
 
         $this->removeUnsupportedHooks();
 

--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -53,7 +53,9 @@ class PostSale extends \Frontend
     {
         parent::__construct();
         
-        \define('FE_USER_LOGGED_IN', false);
+        if (!\defined('FE_USER_LOGGED_IN')) {
+            \define('FE_USER_LOGGED_IN', false);
+        }
 
         $this->removeUnsupportedHooks();
 


### PR DESCRIPTION
Request from payment provider to `system/modules/isotope/postsale.php`:
```
ErrorException: Use of undefined constant FE_USER_LOGGED_IN - assumed 'FE_USER_LOGGED_IN' (this will throw an Error in a future version of PHP)
#14 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductCollection/Cart.php(55): handleError
#13 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductCollection/Cart.php(55): getBillingAddress
#12 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Isotope.php(273): calculatePrice
#11 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductPrice.php(90): getOriginalAmount
#10 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Collection/ProductPrice.php(95): getOriginalAmount
#9 /templates/iso_collection_cart.html5(65): include
#8 /system/modules/core/library/Contao/BaseTemplate.php(88): parse
#7 /system/modules/core/library/Contao/Template.php(277): parse
#6 /system/modules/core/classes/FrontendTemplate.php(46): parse
#5 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php(480): getNotificationTokens
#4 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php(303): updateOrderStatus
#3 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php(222): checkout
#2 /vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/Payment/PSP.php(125): processPostsale
#1 postsale.php(175): run
#0 postsale.php(245): null
```