### PR TITLE
Save cart before redirect

### DIFF
--- a/system/modules/isotope/library/Isotope/Module/Checkout.php
+++ b/system/modules/isotope/library/Isotope/Module/Checkout.php
@@ -635,6 +635,7 @@ class Checkout extends Module
      */
     public static function redirectToStep($strStep, IsotopeProductCollection $objCollection = null)
     {
+        Isotope::getCart()->save();
         \Controller::redirect(static::generateUrlForStep($strStep, $objCollection));
     }
 


### PR DESCRIPTION
Save the cart before the redirect to ensure all cart data loads on next page load.  There are instances where updateDatabase is called after the next page actually starts loading because the shutdown function is called too late.  Basically, the database isn't updated by the time the next page load's "getCart()" is called.