### PR TITLE
Update tl_iso_payment.xlf

### DIFF
--- a/system/modules/isotope/languages/en/tl_iso_payment.xlf
+++ b/system/modules/isotope/languages/en/tl_iso_payment.xlf
@@ -303,10 +303,10 @@
         <source>Your project password for sofortüberweisung.de</source>
       </trans-unit>
       <trans-unit id="tl_iso_payment.saferpay_accountid.0">
-        <source>Saferpay Account-ID</source>
+        <source>Saferpay Account ID (CustomerId-TerminalId)</source>
       </trans-unit>
       <trans-unit id="tl_iso_payment.saferpay_accountid.1">
-        <source>Please enter your unique Saferpay account id.</source>
+        <source>Please enter your unique Saferpay account id. It should be in the form CustomerId-CustomerId</source>
       </trans-unit>
       <trans-unit id="tl_iso_payment.saferpay_username.0">
         <source>Saferpay API User</source>

--- a/system/modules/isotope/languages/en/tl_iso_payment.xlf
+++ b/system/modules/isotope/languages/en/tl_iso_payment.xlf
@@ -306,7 +306,7 @@
         <source>Saferpay Account ID (CustomerId-TerminalId)</source>
       </trans-unit>
       <trans-unit id="tl_iso_payment.saferpay_accountid.1">
-        <source>Please enter your unique Saferpay account id. It should be in the form CustomerId-CustomerId</source>
+        <source>Please enter your unique Saferpay account id. It should be in the form CustomerId-TerminalId</source>
       </trans-unit>
       <trans-unit id="tl_iso_payment.saferpay_username.0">
         <source>Saferpay API User</source>


### PR DESCRIPTION
The wording `Please enter your unique Saferpay account id` is a bit too vague and took me off. It may have been in an earlier version that Saferpay account Id has Terminal Id included. But now, in order to keep working with the current implementation of `/system/modules/isotope/library/Isotope/Model/Payment/Saferpay.php`, one has to provide both CustomerId and TerminalId, separated by `-`.