### PR TITLE
DHL Business Shipment: epk->ekp and invalid name of the function setEpk

### DIFF
--- a/system/modules/isotope/dca/tl_iso_shipping.php
+++ b/system/modules/isotope/dca/tl_iso_shipping.php
@@ -130,7 +130,7 @@ $GLOBALS['TL_DCA']['tl_iso_shipping'] = array
         'flatperWeight'             => '{title_legend},name,label,type;{note_legend:hide},note;{price_legend},price,tax_class,flatCalculation,flatWeight;{config_legend},countries,subdivisions,postalCodes,quantity_mode,minimum_quantity,maximum_quantity,minimum_total,maximum_total,minimum_weight,maximum_weight,product_types,product_types_condition,config_ids,address_type;{expert_legend:hide},guests,protected;{enabled_legend},enabled',
         'product_price'             => '{title_legend},name,label,type;{note_legend:hide},note;{price_legend},tax_class;{config_legend},countries,subdivisions,postalCodes,quantity_mode,minimum_quantity,maximum_quantity,minimum_total,maximum_total,minimum_weight,maximum_weight,product_types,product_types_condition,config_ids,address_type;{expert_legend:hide},guests,protected;{enabled_legend},enabled',
         'group'                     => '{title_legend},name,label,type,inherit;{note_legend:hide},note;{config_legend},group_methods;{price_legend},group_calculation,tax_class;{expert_legend:hide},guests,protected;{enabled_legend},enabled',
-        'dhl_business'              => '{title_legend},name,label,type;{note_legend:hide},note;{api_legend},dhl_user,dhl_signature,dhl_epk,dhl_product,dhl_app,dhl_token,dhl_shipping;{price_legend},price,tax_class,flatCalculation,shipping_weight;{config_legend},countries,subdivisions,postalCodes,quantity_mode,minimum_quantity,maximum_quantity,minimum_total,maximum_total,minimum_weight,maximum_weight,product_types,product_types_condition,config_ids,address_type;{expert_legend:hide},guests,protected;{enabled_legend},enabled,debug,logging',
+        'dhl_business'              => '{title_legend},name,label,type;{note_legend:hide},note;{api_legend},dhl_user,dhl_signature,dhl_ekp,dhl_product,dhl_app,dhl_token,dhl_shipping;{price_legend},price,tax_class,flatCalculation,shipping_weight;{config_legend},countries,subdivisions,postalCodes,quantity_mode,minimum_quantity,maximum_quantity,minimum_total,maximum_total,minimum_weight,maximum_weight,product_types,product_types_condition,config_ids,address_type;{expert_legend:hide},guests,protected;{enabled_legend},enabled,debug,logging',
     ),
 
     // Subpalettes
@@ -428,9 +428,9 @@ $GLOBALS['TL_DCA']['tl_iso_shipping'] = array
             'eval'                  => array('mandatory'=>true, 'maxlength'=>32, 'decodeEntities'=>true, 'hideInput'=>true, 'tl_class'=>'w50'),
             'sql'                   => "varchar(32) NULL",
         ),
-        'dhl_epk' => array
+        'dhl_ekp' => array
         (
-            'label'                 => &$GLOBALS['TL_LANG']['tl_iso_shipping']['dhl_epk'],
+            'label'                 => &$GLOBALS['TL_LANG']['tl_iso_shipping']['dhl_ekp'],
             'exclude'               => true,
             'inputType'             => 'text',
             'eval'                  => array('mandatory'=>true, 'maxlength'=>32, 'tl_class'=>'w50'),

--- a/system/modules/isotope/languages/cs/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/cs/tl_iso_shipping.xlf
@@ -181,10 +181,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/da/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/da/tl_iso_shipping.xlf
@@ -188,10 +188,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/de/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/de/tl_iso_shipping.xlf
@@ -241,11 +241,11 @@
         <source>Please enter your DHL account password.</source>
         <target>Bitte geben Sie Ihr DHL Passwort ein.</target>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
         <target>Kontonummer</target>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
         <target>Bitte geben Sie Ihre DHL Kontonummer ein.</target>
       </trans-unit>

--- a/system/modules/isotope/languages/en/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/en/tl_iso_shipping.xlf
@@ -182,10 +182,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/es/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/es/tl_iso_shipping.xlf
@@ -208,10 +208,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/fa/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/fa/tl_iso_shipping.xlf
@@ -183,10 +183,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/fi/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/fi/tl_iso_shipping.xlf
@@ -181,10 +181,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/fr/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/fr/tl_iso_shipping.xlf
@@ -222,10 +222,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/it/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/it/tl_iso_shipping.xlf
@@ -205,10 +205,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/nl/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/nl/tl_iso_shipping.xlf
@@ -222,10 +222,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/pl/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/pl/tl_iso_shipping.xlf
@@ -222,10 +222,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/pt_BR/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/pt_BR/tl_iso_shipping.xlf
@@ -181,10 +181,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/ru/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/ru/tl_iso_shipping.xlf
@@ -187,10 +187,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/sl/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/sl/tl_iso_shipping.xlf
@@ -189,10 +189,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/languages/tr/tl_iso_shipping.xlf
+++ b/system/modules/isotope/languages/tr/tl_iso_shipping.xlf
@@ -229,10 +229,10 @@
       <trans-unit id="tl_iso_shipping.dhl_signature.1">
         <source>Please enter your DHL account password.</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.0">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.0">
         <source>Account Number</source>
       </trans-unit>
-      <trans-unit id="tl_iso_shipping.dhl_epk.1">
+      <trans-unit id="tl_iso_shipping.dhl_ekp.1">
         <source>Please enter your DHL account number.</source>
       </trans-unit>
       <trans-unit id="tl_iso_shipping.dhl_product.0">

--- a/system/modules/isotope/library/Isotope/EventListener/DHLBusinessCheckoutListener.php
+++ b/system/modules/isotope/library/Isotope/EventListener/DHLBusinessCheckoutListener.php
@@ -77,7 +77,7 @@ class DHLBusinessCheckoutListener
 
         $credentials->setUser($shipping->dhl_user);
         $credentials->setSignature($shipping->dhl_signature);
-        $credentials->setEpk($shipping->dhl_epk);
+        $credentials->setEkp($shipping->dhl_ekp);
         $credentials->setApiUser($shipping->dhl_app);
         $credentials->setApiPassword($shipping->dhl_token);
 
@@ -142,7 +142,7 @@ class DHLBusinessCheckoutListener
             $scale->add($shippingWeight);
         }
 
-        $details = new ShipmentDetails($shippingMethod->dhl_epk);
+        $details = new ShipmentDetails($shippingMethod->dhl_ekp);
 
         $details->setProduct($shippingMethod->dhl_product);
         $details->setCustomerReference($order->getDocumentNumber());

--- a/system/modules/isotope/library/Isotope/Model/Shipping/DHLBusiness.php
+++ b/system/modules/isotope/library/Isotope/Model/Shipping/DHLBusiness.php
@@ -14,7 +14,7 @@ namespace Isotope\Model\Shipping;
 /**
  * @property string $dhl_user
  * @property string $dhl_signature
- * @property string $dhl_epk
+ * @property string $dhl_ekp
  * @property string $dhl_product
  * @property string $dhl_app
  * @property string $dhl_token


### PR DESCRIPTION
There was a typo in the original module:

"epk" should be "ekp"

See also DHL Kundennummer (EKP):
https://www.dhl.de/content/dam/dhlde/external/dhl-anwenderhandbuch-gk-portal.pdf

The setEpk() funciton is deprecated:
https://github.com/Petschko/dhl-php-sdk/blob/451e5ffd03c17c639d841537d31d9ce26d05b79c/includes/Credentials.php#L226

There is a new setEkp() function:
https://github.com/Petschko/dhl-php-sdk/blob/451e5ffd03c17c639d841537d31d9ce26d05b79c/includes/Credentials.php#L217