### PR TITLE
Add missing $ to class properties

### DIFF
--- a/system/modules/isotope/library/Isotope/BackendModule/Integrity.php
+++ b/system/modules/isotope/library/Isotope/BackendModule/Integrity.php
@@ -17,7 +17,7 @@ use Isotope\Interfaces\IsotopeIntegrityCheck;
 /**
  * Class Integrity
  *
- * @property \Template|object Template
+ * @property \Template|object $Template
  */
 class Integrity extends \BackendModule
 {

--- a/system/modules/isotope/library/Isotope/Model/Address.php
+++ b/system/modules/isotope/library/Isotope/Model/Address.php
@@ -23,29 +23,29 @@ use Isotope\Isotope;
 /**
  * Class Address
  *
- * @property int    id
- * @property int    pid
- * @property string ptable
- * @property string label
- * @property int    store_id
- * @property string gender
- * @property string salutation
- * @property string firstname
- * @property string lastname
- * @property int    dateOfBirth
- * @property string company
- * @property string vat_no
- * @property string street_1
- * @property string street_2
- * @property string street_3
- * @property string postal
- * @property string city
- * @property string subdivision
- * @property string country
- * @property string phone
- * @property string email
- * @property bool   isDefaultShipping
- * @property bool   isDefaultBilling
+ * @property int    $id
+ * @property int    $pid
+ * @property string $ptable
+ * @property string $label
+ * @property int    $store_id
+ * @property string $gender
+ * @property string $salutation
+ * @property string $firstname
+ * @property string $lastname
+ * @property int    $dateOfBirth
+ * @property string $company
+ * @property string $vat_no
+ * @property string $street_1
+ * @property string $street_2
+ * @property string $street_3
+ * @property string $postal
+ * @property string $city
+ * @property string $subdivision
+ * @property string $country
+ * @property string $phone
+ * @property string $email
+ * @property bool   $isDefaultShipping
+ * @property bool   $isDefaultBilling
  */
 class Address extends \Model
 {

--- a/system/modules/isotope/library/Isotope/Model/AttributeOption.php
+++ b/system/modules/isotope/library/Isotope/Model/AttributeOption.php
@@ -20,19 +20,19 @@ use Isotope\Isotope;
 /**
  * Class AttributeOption
  *
- * @property int    id
- * @property int    pid
- * @property int    sorting
- * @property int    tstamp
- * @property string ptable
- * @property int    langPid
- * @property string language
- * @property string field_name
- * @property string type
- * @property bool   isDefault
- * @property string label
- * @property string price
- * @property bool   published
+ * @property int    $id
+ * @property int    $pid
+ * @property int    $sorting
+ * @property int    $tstamp
+ * @property string $ptable
+ * @property int    $langPid
+ * @property string $language
+ * @property string $field_name
+ * @property string $type
+ * @property bool   $isDefault
+ * @property string $label
+ * @property string $price
+ * @property bool   $published
  */
 class AttributeOption extends \MultilingualModel
 {

--- a/system/modules/isotope/library/Isotope/Model/Gallery.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery.php
@@ -18,19 +18,19 @@ use Isotope\Model\Gallery\Standard as StandardGallery;
  * Gallery is the parent class for all gallery types
  *
  *
- * @property int    id
- * @property int    tstamp
- * @property string name
- * @property string type
- * @property string anchor
- * @property string placeholder
- * @property string main_size
- * @property string main_watermark_image
- * @property string main_watermark_position
- * @property string gallery_size
- * @property string gallery_watermark_image
- * @property string gallery_watermark_position
- * @property string customTpl
+ * @property int    $id
+ * @property int    $tstamp
+ * @property string $name
+ * @property string $type
+ * @property string $anchor
+ * @property string $placeholder
+ * @property string $main_size
+ * @property string $main_watermark_image
+ * @property string $main_watermark_position
+ * @property string $gallery_size
+ * @property string $gallery_watermark_image
+ * @property string $gallery_watermark_position
+ * @property string $customTpl
  */
 abstract class Gallery extends TypeAgent
 {

--- a/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
@@ -20,10 +20,10 @@ use Isotope\Template;
 /**
  * Standard implements a lightbox gallery
  *
- * @property string lightbox_size
- * @property string lightbox_watermark_image
- * @property string lightbox_watermark_position
- * @property string lightbox_template
+ * @property string $lightbox_size
+ * @property string $lightbox_watermark_image
+ * @property string $lightbox_watermark_position
+ * @property string $lightbox_template
  */
 class Standard extends Gallery implements IsotopeGallery
 {

--- a/system/modules/isotope/library/Isotope/Model/Payment/Sofortueberweisung.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Sofortueberweisung.php
@@ -22,7 +22,7 @@ use Isotope\Template;
  *
  * @property string $sofortueberweisung_user_id
  * @property string $sofortueberweisung_project_id
- * @property string sofortueberweisung_project_password
+ * @property string $sofortueberweisung_project_password
  */
 class Sofortueberweisung extends Postsale
 {

--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
@@ -24,21 +24,21 @@ use Isotope\Model\ProductCollectionSurcharge\Tax;
  *
  * Provide methods to handle Isotope product collection surcharges.
  *
- * @property int    id
- * @property int    pid
- * @property int    sorting
- * @property int    tstamp
- * @property string type
- * @property int    source_id
- * @property string label
- * @property string price
- * @property float  total_price
- * @property float  tax_free_total_price
- * @property string tax_id
- * @property bool   before_tax
- * @property bool   addToTotal
- * @property bool   applyRoundingIncrement
- * @property array  products
+ * @property int    $id
+ * @property int    $pid
+ * @property int    $sorting
+ * @property int    $tstamp
+ * @property string $type
+ * @property int    $source_id
+ * @property string $label
+ * @property string $price
+ * @property float  $total_price
+ * @property float  $tax_free_total_price
+ * @property string $tax_id
+ * @property bool   $before_tax
+ * @property bool   $addToTotal
+ * @property bool   $applyRoundingIncrement
+ * @property array  $products
  */
 abstract class ProductCollectionSurcharge extends TypeAgent
 {

--- a/system/modules/isotope/library/Isotope/Model/Shipping/Flat.php
+++ b/system/modules/isotope/library/Isotope/Model/Shipping/Flat.php
@@ -19,8 +19,8 @@ use Isotope\Model\Shipping;
 /**
  * Class Flat
  *
- * @property string flatCalculation
- * @property string flatWeight
+ * @property string $flatCalculation
+ * @property string $flatWeight
  */
 class Flat extends Shipping
 {

--- a/system/modules/isotope/library/Isotope/Model/Shipping/Group.php
+++ b/system/modules/isotope/library/Isotope/Model/Shipping/Group.php
@@ -18,8 +18,8 @@ use Isotope\Model\Shipping;
 /**
  * Class Group
  *
- * @property array  group_methods
- * @property string group_calculation
+ * @property array  $group_methods
+ * @property string $group_calculation
  */
 class Group extends Shipping
 {

--- a/system/modules/isotope/library/Isotope/Model/TaxClass.php
+++ b/system/modules/isotope/library/Isotope/Model/TaxClass.php
@@ -17,15 +17,15 @@ use Isotope\Translation;
 /**
  * TaxRate implements the tax class model.
  *
- * @property int    id
- * @property int    tstamp
- * @property string name
- * @property bool   fallback
- * @property int    includes
- * @property string label
- * @property array  rates
- * @property bool   applyRoundingIncrement
- * @property bool   notNegative
+ * @property int    $id
+ * @property int    $tstamp
+ * @property string $name
+ * @property bool   $fallback
+ * @property int    $includes
+ * @property string $label
+ * @property array  $rates
+ * @property bool   $applyRoundingIncrement
+ * @property bool   $notNegative
  */
 class TaxClass extends \Model
 {

--- a/system/modules/isotope/library/Isotope/Model/TaxRate.php
+++ b/system/modules/isotope/library/Isotope/Model/TaxRate.php
@@ -19,23 +19,23 @@ use Isotope\Translation;
 /**
  * TaxRate implements the tax rate model.
  *
- * @property int    id
- * @property int    pid
- * @property int    tstamp
- * @property string name
- * @property string label
- * @property array  address
- * @property array  countries
- * @property array  subdivisions
- * @property string postalCodes
- * @property array  rate
- * @property array  amount
- * @property int    config
- * @property bool   exemptOnValidVAT
- * @property bool   stop
- * @property bool   guests
- * @property bool   protected
- * @property array  groups
+ * @property int    $id
+ * @property int    $pid
+ * @property int    $tstamp
+ * @property string $name
+ * @property string $label
+ * @property array  $address
+ * @property array  $countries
+ * @property array  $subdivisions
+ * @property string $postalCodes
+ * @property array  $rate
+ * @property array  $amount
+ * @property int    $config
+ * @property bool   $exemptOnValidVAT
+ * @property bool   $stop
+ * @property bool   $guests
+ * @property bool   $protected
+ * @property array  $groups
  */
 class TaxRate extends \Model
 {


### PR DESCRIPTION
Working with many of the models of Isotope in an IDE is currently a bit cumbersome because the first character is cut off by my IDE during auto-completion - because the `$` is missing:

<img src="https://user-images.githubusercontent.com/4970961/85960108-e23c6d80-b998-11ea-818a-d686204fd0f4.png" width="429">

This PR adds the missing `$` for those properties.
