### PR TITLE
Allow for response codes 303 and 307 for redirects

### DIFF
--- a/system/modules/isotope/assets/js/backend.js
+++ b/system/modules/isotope/assets/js/backend.js
@@ -108,7 +108,7 @@ var Isotope = {};
                     }
                 },
                 onFailure: function(xhr) {
-                    if (xhr.status === 302 && xhr.responseText != '') {
+                    if ([302,303,307].indexOf(xhr.status) > -1 && xhr.responseText != '') {
                         window.location.href = xhr.responseText;
                     }
                 }
@@ -188,7 +188,7 @@ var Isotope = {};
                     }
                 },
                 onFailure: function(xhr) {
-                    if (xhr.status === 302 && xhr.responseText != '') {
+                    if ([302,303,307].indexOf(xhr.status) > -1 && xhr.responseText != '') {
                         window.location.href = xhr.responseText;
                     }
                 }


### PR DESCRIPTION
For Contao 4.10, Isotope needs to allow for response codes 303 and 307.  307 was used for a short time, but we should account for it anyway.