### PR TITLE
Added `decodeEntities` to eval-Array of the Checkout-Step-Selection. 

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Module/OrderConditionFields.php
+++ b/system/modules/isotope/library/Isotope/Backend/Module/OrderConditionFields.php
@@ -38,6 +38,7 @@ class OrderConditionFields extends \Backend
                 'inputType' => 'select',
                 'options_callback' => ['Isotope\Backend\Module\OrderConditionFields', 'getSteps'],
                 'eval' => [
+                    'decodeEntities' => true,
                     'includeBlankOption' => true,
                     'style' => 'width:300px',
                     'columnPos' => 'checkout',


### PR DESCRIPTION
Validation fails otherwise because of the backslashes in the option values. Closes #2193