### PR TITLE
Fix warning if no options have been created yet

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Attribute.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute.php
@@ -257,21 +257,25 @@ abstract class Attribute extends TypeAgent implements IsotopeAttribute
 
                 case IsotopeAttributeWithOptions::SOURCE_TABLE:
                     $arrOptions = [];
-                    foreach (AttributeOption::findByAttribute($this, ['order' => AttributeOption::getTable().'.label']) ?? [] as $model) {
-                        $arrOptions[] = [
-                            'value' => $model->getLanguageId(),
-                            'label' => $model->label,
-                        ];
+                    if (null !== ($options = AttributeOption::findByAttribute($this, ['order' => AttributeOption::getTable().'.label']))) {
+                        foreach ($options as $model) {
+                            $arrOptions[] = [
+                                'value' => $model->getLanguageId(),
+                                'label' => $model->label,
+                            ];
+                        }
                     }
                     break;
 
                 case IsotopeAttributeWithOptions::SOURCE_PRODUCT:
                     $arrOptions = [];
-                    foreach (AttributeOption::findByProducts($this, ['order' => AttributeOption::getTable().'.label']) ?? [] as $model) {
-                        $arrOptions[] = [
-                            'value' => $model->getLanguageId(),
-                            'label' => $model->label,
-                        ];
+                    if (null !== ($options = AttributeOption::findByProducts($this, ['order' => AttributeOption::getTable().'.label']))) {
+                        foreach ($options as $model) {
+                            $arrOptions[] = [
+                                'value' => $model->getLanguageId(),
+                                'label' => $model->label,
+                            ];
+                        }
                     }
                     break;
 

--- a/system/modules/isotope/library/Isotope/Model/Attribute.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute.php
@@ -257,7 +257,7 @@ abstract class Attribute extends TypeAgent implements IsotopeAttribute
 
                 case IsotopeAttributeWithOptions::SOURCE_TABLE:
                     $arrOptions = [];
-                    foreach (AttributeOption::findByAttribute($this, ['order' => AttributeOption::getTable().'.label']) as $model) {
+                    foreach (AttributeOption::findByAttribute($this, ['order' => AttributeOption::getTable().'.label']) ?? [] as $model) {
                         $arrOptions[] = [
                             'value' => $model->getLanguageId(),
                             'label' => $model->label,
@@ -267,7 +267,7 @@ abstract class Attribute extends TypeAgent implements IsotopeAttribute
 
                 case IsotopeAttributeWithOptions::SOURCE_PRODUCT:
                     $arrOptions = [];
-                    foreach (AttributeOption::findByProducts($this, ['order' => AttributeOption::getTable().'.label']) as $model) {
+                    foreach (AttributeOption::findByProducts($this, ['order' => AttributeOption::getTable().'.label']) ?? [] as $model) {
                         $arrOptions[] = [
                             'value' => $model->getLanguageId(),
                             'label' => $model->label,


### PR DESCRIPTION
This PR fixes the following error:

```
ErrorException:
Warning: Invalid argument supplied for foreach()

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Model\Attribute.php:270
  at Isotope\Model\Attribute->saveToDCA()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Model\Attribute\AbstractAttributeWithOptions.php:401)
  at Isotope\Model\Attribute\AbstractAttributeWithOptions->saveToDCA()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Model\Attribute\SelectMenu.php:47)
  at Isotope\Model\Attribute\SelectMenu->saveToDCA()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\Product\DcaManager.php:118)
  at Isotope\Backend\Product\DcaManager->addAttributes()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\Product\DcaManager.php:40)
  at Isotope\Backend\Product\DcaManager->initialize()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\DcaLoader.php:118)
  at Contao\DcaLoader->loadDcaFiles()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\DcaLoader.php:70)
  at Contao\DcaLoader->load()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Controller.php:1362)
  at Contao\Controller::loadDataContainer()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductType\Permission.php:44)
  at Isotope\Backend\ProductType\Permission::check()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:202)
  at Contao\DC_Table->__construct()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:411)
  at Contao\Backend->getBackendModule()
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:167)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:48)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web\index.php:31)
  at require('web\\index.php')
     (web\app.php:4)     
```

This happens if no options for a select/radio attribute have been created yet.