### PR TITLE
Check for order condition form

### DIFF
--- a/system/modules/isotope/library/Isotope/Module/Checkout.php
+++ b/system/modules/isotope/library/Isotope/Module/Checkout.php
@@ -585,6 +585,10 @@ class Checkout extends Module
         $productTypeIds = array_unique($productTypeIds);
 
         foreach (deserialize($this->iso_order_conditions, true) as $config) {
+            if (empty($config['form'])) {
+                continue;
+            }
+
             $configProductTypes = deserialize($config['product_types']);
 
             if (!empty($configProductTypes) && \is_array($configProductTypes)) {


### PR DESCRIPTION
By default, the `iso_order_conditions` multi column wizard widget produces an output like this, if you do not set any values:

```
array:1 [▼
  0 => array:5 [▼
    "form" => ""
    "step" => ""
    "position" => "before"
    "product_types" => ""
    "product_types_condition" => "oneAvailable"
  ]
]
```

This causes an invalid entry to be added to `$arrOrderConditions`. While this has no real effect in the front end, it seems safer and more optimised to ignore any order conditions entry where no actual form is configured (like the default one).

This also fixes an illegal array access that can occur, if the MCW saves wrong data into the field (which happened in one of our instances, though I cannot reproduce it).