### PR TITLE
Performance optimisation in backend product list

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Product/Permission.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Permission.php
@@ -178,7 +178,7 @@ class Permission extends \Backend
             $arrProducts = array_merge(
                 $arrProducts,
                 \Database::getInstance()->execute(
-                    "SELECT id FROM tl_iso_product WHERE language='' AND ".\Database::getInstance()->findInSet('pid', $arrProducts)
+                    "SELECT id FROM tl_iso_product WHERE language='' AND pid IN(".implode(',', $arrProducts).")"
                 )->fetchEach('id')
             );
         }


### PR DESCRIPTION
As a user with restricted product types, we encountered a long page loading from more than 3 seconds (30 products per page) in Contao backend.
The products table contains more than 20'000 rows with lots of variants.

With this little change, the database request time is ~100ms (seems that FIND IN SET is not using the existing "pid" index).