### PR TITLE
Remove system log error entry for missing tl_module.iso_notifications

### DIFF
--- a/system/modules/isotope/dca/tl_module.php
+++ b/system/modules/isotope/dca/tl_module.php
@@ -685,7 +685,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['iso_notifications'] = array
     'exclude'                   => true,
     'inputType'                 => 'select',
     'options_callback'          => array('NotificationCenter\tl_module', 'getNotificationChoices'),
-    'eval'                      => array('multiple'=>true, 'csv'=>',', 'includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
+    'eval'                      => array('multiple'=>true, 'csv'=>',', 'includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50', 'mandatory'=>true),
     'sql'                       => "varchar(255) NOT NULL default ''",
     'relation'                  => array('type'=>'hasOne', 'load'=>'lazy', 'table'=>'tl_nc_notification'),
 );

--- a/system/modules/isotope/dca/tl_module.php
+++ b/system/modules/isotope/dca/tl_module.php
@@ -685,7 +685,7 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['iso_notifications'] = array
     'exclude'                   => true,
     'inputType'                 => 'select',
     'options_callback'          => array('NotificationCenter\tl_module', 'getNotificationChoices'),
-    'eval'                      => array('multiple'=>true, 'csv'=>',', 'includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50', 'mandatory'=>true),
+    'eval'                      => array('multiple'=>true, 'csv'=>',', 'includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
     'sql'                       => "varchar(255) NOT NULL default ''",
     'relation'                  => array('type'=>'hasOne', 'load'=>'lazy', 'table'=>'tl_nc_notification'),
 );

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php
@@ -217,8 +217,6 @@ class Order extends ProductCollection implements IsotopePurchasableCollection
                     \System::log('Error sending new order notification for order ID ' . $this->id, __METHOD__, TL_ERROR);
                 }
             }
-        } else {
-            \System::log('No notification for order ID ' . $this->id, __METHOD__, TL_ERROR);
         }
 
         // Set order status only if a payment module has not already set it


### PR DESCRIPTION
If you do not define a notification in the `iso_checkout` module then the following error will appear in the system log:

```
No notification for order ID …
```

This error entry is created here:

https://github.com/isotope/core/blob/5e3d7972cd91d782faf9f11a17deac89ccddc559/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php#L198-L222

Since this effectively makes this setting mandatory (otherwise your system log will be filled with errors with every order in the shop) it should be set to `mandatory` in the DCA as well to avoid confusion.

Alternatively

https://github.com/isotope/core/blob/5e3d7972cd91d782faf9f11a17deac89ccddc559/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php#L220-L222

could be removed altogether since it is perfectly possible to set the notification _only_ in the `OrderStatus`.