### PR TITLE
Fix order list view when using permissions

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
@@ -265,6 +265,8 @@ class Callback extends \Backend
         if (\is_array($arrGroups) && !empty($arrGroups)) {
             $blnGuests = \in_array(-1, $arrGroups, false);
             $arrLike = [];
+            $memberIds = [];
+
             foreach ($arrGroups as $id) {
                 if ($id == -1) {
                     continue;
@@ -274,9 +276,11 @@ class Callback extends \Backend
                 $arrLike[] = "tl_member.groups LIKE '%i:$id;%'";
             }
 
-            $memberIds = \Database::getInstance()->execute(
-                'SELECT id FROM tl_member WHERE '.implode(' OR ', $arrLike)
-            )->fetchEach('id');
+            if (!empty($arrLike)) {
+                $memberIds = \Database::getInstance()->execute(
+                    'SELECT id FROM tl_member WHERE '.implode(' OR ', $arrLike)
+                )->fetchEach('id');
+            }
 
             if ($blnGuests) {
                 array_unshift($memberIds, 0);


### PR DESCRIPTION
Fixes #2213

**Reproduction:** 

1. Create a new back end user group with all the necessary permissions to view Isotope orders.
2. Only select _Guests_ in _Account manager_ » _User groups_ » _&lt;group&gt;_ » _Isotope eCommerce_ » **Allowed member group**.
3. Create a new non-admin back end user and assign this group.
4. Log in as the new back end user and try to view the orders in the back end.

The following error will occur:

```
Doctrine\DBAL\Exception\SyntaxErrorException:
An exception occurred while executing 'SELECT id FROM tl_member WHERE':

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '' at line 1

  at vendor\doctrine\dbal\lib\Doctrine\DBAL\Driver\AbstractMySQLDriver.php:98
  at Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException()
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\DBALException.php:182)
  at Doctrine\DBAL\DBALException::wrapException()
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\DBALException.php:159)
  at Doctrine\DBAL\DBALException::driverExceptionDuringQuery()
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\Connection.php:2121)
  at Doctrine\DBAL\Connection->handleExceptionDuringQuery()
     (vendor\doctrine\dbal\lib\Doctrine\DBAL\Connection.php:1264)
  at Doctrine\DBAL\Connection->executeQuery()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:274)
  at Contao\Database\Statement->query()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Database\Statement.php:248)
  at Contao\Database\Statement->execute()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Database.php:194)
  at Contao\Database->execute()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductCollection\Callback.php:278)
  at Isotope\Backend\ProductCollection\Callback->checkPermission()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:203)
  at Contao\DC_Table->__construct()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:411)
  at Contao\Backend->getBackendModule()
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:167)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:48)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:158)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:80)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:201)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (web\index.php:31)
  at require('web\\index.php')
     (web\app.php:4)              
```

This PR fixes that by implementing an additional check on whether the produced `$arrLike` array is empty, otherwise and invalid SQL query would be executed leading to this error.