### PR TITLE
Improve layout of order details in back end

### DIFF
--- a/system/modules/isotope/assets/css/backend.css
+++ b/system/modules/isotope/assets/css/backend.css
@@ -162,6 +162,10 @@ table.multicolumnwizard .operations {
     white-space: nowrap;
 }
 
+.mod_iso_orderdetails .order_status {
+    margin: 1em 0;
+}
+
 .mod_iso_orderdetails .info_container {
     float:left;
     width:200px;
@@ -172,7 +176,9 @@ table.multicolumnwizard .operations {
 
 .mod_iso_orderdetails .info_container h3 {
     margin-top: 0;
-    margin-bottom: 5px
+    margin-bottom: 5px;
+    padding-top: 0;
+    height: auto;
 }
 
 .mod_iso_orderdetails table {


### PR DESCRIPTION
This PR improves the layout of order details for the back end in Contao 4.

**Before**

<img src="https://user-images.githubusercontent.com/4970961/115264388-2b2eff80-a12e-11eb-8aef-7f305ec718c3.png" width="721">

**After**

<img src="https://user-images.githubusercontent.com/4970961/115264410-308c4a00-a12e-11eb-859b-3c85893957e6.png" width="648">

Should be fine for Contao 3 as well, but I haven't tested it specifically.