### PR TITLE
Fix mandatory file uploads in order conditions not working

### DIFF
--- a/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
+++ b/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
@@ -114,7 +114,11 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep
 
                 // Clone widget because otherwise we add errors to the original widget instance
                 $objClone = clone $this->objForm->getWidget($strField);
-                \Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField]);
+                if ($this->objForm->getWidget($strField) instanceof \uploadable) {
+                    $_FILES[$strField] = $_SESSION['FILES'][$strField];
+                } else {
+                    \Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField]);
+                }
                 $objClone->validate();
 
                 if ($objClone->hasErrors()) {

--- a/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
+++ b/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
@@ -114,7 +114,7 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep
 
                 // Clone widget because otherwise we add errors to the original widget instance
                 $objClone = clone $this->objForm->getWidget($strField);
-                if ($this->objForm->getWidget($strField) instanceof \uploadable) {
+                if ($objClone instanceof \uploadable) {
                     $_FILES[$strField] = $_SESSION['FILES'][$strField];
                 } else {
                     \Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField]);


### PR DESCRIPTION
Currently mandatory file uploads in order conditions do not work. When the form is submitted, Isotope will stay at the `checkout/review` step, without showing any error. The problem is that when `checkout/process` processes the order conditions checkout step again, `$_FILES` will be empty at this point and thus the file upload widget will not validate and therefore the whole order condition step will not validate, even though it was valid during the `POST` request.

To fix this `$_FILES` will need to be repopulated for the cloned widget when the checkout is processed.