### PR TITLE
Consider sendNotificationMessage Hook

### DIFF
--- a/system/modules/isotope/postsale.php
+++ b/system/modules/isotope/postsale.php
@@ -235,6 +235,7 @@ class PostSale extends \Frontend
                     'getAttributesFromDca',
                     'loadDataContainer',
                     'replaceInsertTags',
+                    'sendNotificationMessage',
                 ]
             )
         );


### PR DESCRIPTION
Since Isotope uses Notification-Center it should support sendNotificationMessage Hook from Notification-Center. With this Bundle you can send different notifications dependant on product: https://github.com/postyou/isotope_notification_product_extension
This does actually not work because postsale.php removes the Hook. See #2174