### PR TITLE
Übersetzungen #2239, #2240, #2237

### DIFF
--- a/system/modules/isotope/languages/de/tl_iso_config.xlf
+++ b/system/modules/isotope/languages/de/tl_iso_config.xlf
@@ -167,7 +167,7 @@
       </trans-unit>
       <trans-unit id="tl_iso_config.address_fields.1">
         <source>Select the fields for a billing and shipping address when checking out.</source>
-        <target>Wählen Sie die Felder für die Rechnungs- und Versandadresse beim bezahlen aus.</target>
+        <target>Wählen Sie die Felder für die Rechnungs- und Versandadresse beim Bezahlen aus.</target>
       </trans-unit>
       <trans-unit id="tl_iso_config.address_fields.billing.0">
         <source>For billing address</source>

--- a/system/modules/isotope/languages/de/tl_iso_product_collection.xlf
+++ b/system/modules/isotope/languages/de/tl_iso_product_collection.xlf
@@ -141,6 +141,14 @@
         <source>Edit order ID %s</source>
         <target>Bestellung ID %s bearbeiten</target>
       </trans-unit>
+      <trans-unit id="tl_iso_product_collection.delete.0">
+        <source>Delete order</source>
+        <target>Bestellung löschen</target>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection.delete.1">
+        <source>Delete order ID %s</source>
+        <target>Bestellung ID %s löschen</target>
+      </trans-unit>
       <trans-unit id="tl_iso_product_collection.payment.0">
         <source>Payment details</source>
         <target>Zahlungsdetails</target>

--- a/system/modules/isotope/languages/de/tl_iso_product_collection_log.xlf
+++ b/system/modules/isotope/languages/de/tl_iso_product_collection_log.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/tl_iso_product_collection_log.xlf" source-language="en">
+    <body>
+      <trans-unit id="tl_iso_product_collection_log.id.0">
+        <source>ID</source>
+        <target>ID</target>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection_log.tstamp.0">
+        <source>Date created</source>
+        <target>Erstellungsdatum</target>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection_log.author.0">
+        <source>Author</source>
+        <target>Autor</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/system/modules/isotope/languages/en/tl_iso_product_collection.xlf
+++ b/system/modules/isotope/languages/en/tl_iso_product_collection.xlf
@@ -107,6 +107,12 @@
       <trans-unit id="tl_iso_product_collection.edit.1">
         <source>Edit order ID %s</source>
       </trans-unit>
+      <trans-unit id="tl_iso_product_collection.delete.0">
+        <source>Delete order</source>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection.delete.1">
+        <source>Delete order ID %s</source>
+      </trans-unit>
       <trans-unit id="tl_iso_product_collection.payment.0">
         <source>Payment details</source>
       </trans-unit>

--- a/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
@@ -53,7 +53,7 @@ class Paypal extends Postsale
             return;
         }
 
-        if (!$this->debug && strcasecmp(\Input::post('receiver_email', true),$this->paypal_account) != 0) {
+        if (!$this->debug && \Input::post('receiver_email', true) != $this->paypal_account) {
             \System::log('PayPal IPN: Account email does not match (got ' . \Input::post('receiver_email', true) . ', expected ' . $this->paypal_account . ')', __METHOD__, TL_ERROR);
             return;
         }

--- a/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
@@ -53,7 +53,7 @@ class Paypal extends Postsale
             return;
         }
 
-        if (!$this->debug && \Input::post('receiver_email', true) != $this->paypal_account) {
+        if (!$this->debug && strcasecmp(\Input::post('receiver_email', true),$this->paypal_account) != 0) {
             \System::log('PayPal IPN: Account email does not match (got ' . \Input::post('receiver_email', true) . ', expected ' . $this->paypal_account . ')', __METHOD__, TL_ERROR);
             return;
         }


### PR DESCRIPTION
Fix für folgende 3 Tickets, da nur Übersetzungen alle zusammen in einem PR.
#2239 - Übersetzung tl_iso_config.address_fields.1
#2240 Änderungs-Historie von Bestellungen: Übersetzung "Date created"
#2237 - Tooltip Bestellung löschen