### PR TITLE
Do not preselect Document (Template) in Backend Order print.

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
@@ -468,7 +468,7 @@ class Callback extends \Backend
             'label'      => &$GLOBALS['TL_LANG']['tl_iso_product_collection']['document_choice'],
             'inputType'  => 'select',
             'foreignKey' => 'tl_iso_document.name',
-            'eval'       => array('mandatory' => true),
+            'eval'       => array('includeBlankOption'=>true, 'mandatory' => true),
         );
 
         $objSelect = new \SelectMenu(\SelectMenu::getAttributesFromDca($arrSelect, $arrSelect['name']));


### PR DESCRIPTION
Please insert a blank option in the document selection drop-down, when printing Orders from the Backend. In this way, the editor is forced to select the correct template.