### PR TITLE
Add missing use statement

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductType/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductType/Callback.php
@@ -15,6 +15,7 @@ use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Controller;
 use Contao\CoreBundle\Exception\AccessDeniedException;
+use Contao\Database;
 use Contao\DataContainer;
 use Contao\Image;
 use Contao\Input;


### PR DESCRIPTION
```
Attempted to load class "Database" from namespace "Isotope\Backend\ProductType".
Did you forget a "use" statement for another namespace?

```