### PR TITLE
fix error in contao 4.13 / symfony http client

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Payment/PaypalApi.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/PaypalApi.php
@@ -236,7 +236,7 @@ abstract class PaypalApi extends Payment
 
         try {
             $response = $client->request('POST', $this->getApiUrl('/oauth2/token'), [
-                'form_params' => ['grant_type' => 'client_credentials'],
+                'body' => ['grant_type' => 'client_credentials'],
                 'headers' => [
                     'Authorization' => 'Basic ' . base64_encode($this->paypal_client . ':' . $this->paypal_secret),
                 ],


### PR DESCRIPTION
fixes the following error:

 PayPal API Error! (Unsupported option "form_params" passed to "Symfony\Component\HttpClient\CurlHttpClient", did you mean "max_duration", "headers", "normalized_headers", "query", "auth_basic", "auth_bearer", "body", "json", "user_data", "max_redirects", "http_version", "base_uri", "buffer", "on_progress", "resolve", "proxy", "no_proxy", "timeout", "bindto", "verify_peer", "verify_host", "cafile", "capath", "local_cert", "local_pk", "passphrase", "ciphers", "peer_fingerprint", "capture_peer_cert_chain", "extra", "auth_ntlm"?)