### PR TITLE
Do not use StringUtil::ampersand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require":{
         "php": "^7.2 || ^8.0",
         "composer-runtime-api": "^2",
-        "contao/core-bundle": "^4.9",
+        "contao/core-bundle": "^4.9.22",
         "contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
         "terminal42/contao-conditionalselectmenu":"^3.0.3 || ^4.0",
         "terminal42/dcawizard": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require":{
         "php": "^7.2 || ^8.0",
         "composer-runtime-api": "^2",
-        "contao/core-bundle": "^4.9.22",
+        "contao/core-bundle": "^4.9",
         "contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
         "terminal42/contao-conditionalselectmenu":"^3.0.3 || ^4.0",
         "terminal42/dcawizard": "^2.3",

--- a/system/modules/isotope/drivers/DC_ProductData.php
+++ b/system/modules/isotope/drivers/DC_ProductData.php
@@ -656,7 +656,7 @@ class DC_ProductData extends \DC_Table
             $version = str_replace(
                 '<div class="tl_version_panel">',
                 '<div class="tl_version_panel tl_iso_products_panel">
-<form action="' . StringUtil::ampersand(\Contao\Environment::get('request'), true) . '" id="tl_language" class="tl_form" method="post">
+<form action="' . ampersand(\Contao\Environment::get('request'), true) . '" id="tl_language" class="tl_form" method="post">
 <div class="tl_formbody">
 <input type="hidden" name="FORM_SUBMIT" value="tl_language">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">
@@ -1271,7 +1271,7 @@ class DC_ProductData extends \DC_Table
 
             // Return the select menu
             $return .= '
-<form action="' . StringUtil::ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
+<form action="' . ampersand(Environment::get('request')) . '&amp;fields=1" id="' . $this->strTable . '_all" class="tl_form tl_edit_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="' . $this->strTable . '_all">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">' . ($blnIsError ? '

--- a/system/modules/isotope/drivers/DC_TablePageId.php
+++ b/system/modules/isotope/drivers/DC_TablePageId.php
@@ -590,7 +590,7 @@ class DC_TablePageId extends \DC_Table
 
         $return .= (('select' === Input::get('act')) ? '
 
-<form action="'.StringUtil::ampersand(Environment::get('request'), true).'" id="tl_select" class="tl_form" method="post" novalidate>
+<form action="'.ampersand(Environment::get('request'), true).'" id="tl_select" class="tl_form" method="post" novalidate>
 <div class="tl_formbody">
 <input type="hidden" name="FORM_SUBMIT" value="tl_select">
 <input type="hidden" name="REQUEST_TOKEN" value="'.REQUEST_TOKEN.'">' : '').($blnClipboard ? '
@@ -1152,7 +1152,7 @@ Isotope.makeParentViewSortable("ul_' . CURRENT_ID . '");
             $result = $objRow->fetchAllAssoc();
             $return .= ((Input::get('act') == 'select') ? '
 
-<form action="'.StringUtil::ampersand(Environment::get('request'), true).'" id="tl_select" class="tl_form" method="post" novalidate>
+<form action="'.ampersand(Environment::get('request'), true).'" id="tl_select" class="tl_form" method="post" novalidate>
 <div class="tl_formbody">
 <input type="hidden" name="FORM_SUBMIT" value="tl_select">
 <input type="hidden" name="REQUEST_TOKEN" value="'.REQUEST_TOKEN.'">' : '').'

--- a/system/modules/isotope/library/Isotope/Backend.php
+++ b/system/modules/isotope/library/Isotope/Backend.php
@@ -20,7 +20,6 @@ use Contao\DataContainer;
 use Contao\Input;
 use Contao\Model;
 use Contao\Session;
-use Contao\StringUtil;
 use Contao\System;
 use Contao\Widget;
 use Isotope\Backend\Product\Permission;
@@ -462,7 +461,7 @@ class Backend extends Contao_Backend
             && Group::getTable() === Input::get('table')
             && 'be_main' === $objTemplate->getName()
         ) {
-            $objTemplate->managerHref = StringUtil::ampersand($this->Session->get('groupPickerRef'));
+            $objTemplate->managerHref = ampersand($this->Session->get('groupPickerRef'));
             $objTemplate->manager     = $GLOBALS['TL_LANG']['MSC']['groupPickerHome'];
         }
     }

--- a/system/modules/isotope/library/Isotope/Backend/Group/Breadcrumb.php
+++ b/system/modules/isotope/library/Isotope/Backend/Group/Breadcrumb.php
@@ -104,13 +104,13 @@ class Breadcrumb extends Backend
             if ((!$intProductId && $intId == $arrGroup['id']) || ($intProductId && $intProductId == $arrGroup['id'])) {
                 $buffer .= '<img src="system/modules/isotope/assets/images/folder-network.png" width="16" height="16" alt="" style="margin-right:6px;">' . $arrGroup['name'];
             } else {
-                $buffer .= '<img src="system/modules/isotope/assets/images/folder-network.png" width="16" height="16" alt="" style="margin-right:6px;"><a href="' . StringUtil::ampersand($strUrl) . '&amp;gid=' . $arrGroup['id'] . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['selectGroup']) . '">' . $arrGroup['name'] . '</a>';
+                $buffer .= '<img src="system/modules/isotope/assets/images/folder-network.png" width="16" height="16" alt="" style="margin-right:6px;"><a href="' . ampersand($strUrl) . '&amp;gid=' . $arrGroup['id'] . '" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['selectGroup']) . '">' . $arrGroup['name'] . '</a>';
             }
 
             $arrLinks[] = $buffer;
         }
 
-        $arrLinks[] = sprintf('<a href="%s" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['allGroups']) . '"><img src="system/modules/isotope/assets/images/folders.png" width="16" height="16" alt="" style="margin-right:6px;"> %s</a>', StringUtil::ampersand($strUrl) . '&amp;gid=0', $GLOBALS['TL_LANG']['MSC']['filterAll']);
+        $arrLinks[] = sprintf('<a href="%s" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['allGroups']) . '"><img src="system/modules/isotope/assets/images/folders.png" width="16" height="16" alt="" style="margin-right:6px;"> %s</a>', ampersand($strUrl) . '&amp;gid=0', $GLOBALS['TL_LANG']['MSC']['filterAll']);
 
         return '
 <ul id="tl_breadcrumb">

--- a/system/modules/isotope/library/Isotope/Backend/Product/AssetImport.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/AssetImport.php
@@ -50,7 +50,7 @@ class AssetImport extends Backend
         // Return form
         return '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=import', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=import', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . $GLOBALS['TL_LANG']['tl_iso_product']['import'][1] . '</h2>
@@ -58,7 +58,7 @@ class AssetImport extends Backend
 <div class="tl_message"><div class="tl_info">' . $GLOBALS['TL_LANG']['tl_iso_product']['importAssetsDescr'] . '</div></div>
 ' . Message::generate() . '
 
-<form action="' . StringUtil::ampersand(Environment::get('request'), true) . '" id="tl_iso_product_import" class="tl_form" method="post">
+<form action="' . ampersand(Environment::get('request'), true) . '" id="tl_iso_product_import" class="tl_form" method="post">
 <div class="tl_formbody_edit iso_importassets">
 <input type="hidden" name="FORM_SUBMIT" value="tl_iso_product_import">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">

--- a/system/modules/isotope/library/Isotope/Backend/Product/Button.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Button.php
@@ -67,7 +67,7 @@ class Button extends Backend
     public function forCopy($row, $href, $label, $title, $icon, $attributes)
     {
         if ($row['pid'] > 0) {
-            return '<a href="' . preg_replace('/&(amp;)?id=[^& ]*/i', '', StringUtil::ampersand(Environment::get('request'))) . '&amp;act=paste&amp;mode=copy&amp;table=tl_iso_product&amp;id=' . $row['id'] . '&amp;pid=' . Input::get('id') . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . ' onclick="Backend.getScrollOffset();">' . Image::getHtml($icon, $label) . '</a> ';
+            return '<a href="' . preg_replace('/&(amp;)?id=[^& ]*/i', '', ampersand(Environment::get('request'))) . '&amp;act=paste&amp;mode=copy&amp;table=tl_iso_product&amp;id=' . $row['id'] . '&amp;pid=' . Input::get('id') . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . ' onclick="Backend.getScrollOffset();">' . Image::getHtml($icon, $label) . '</a> ';
         }
 
         return '<a href="' . Backend::addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ';
@@ -91,7 +91,7 @@ class Button extends Backend
             return '';
         }
 
-        return '<a href="' . preg_replace('/&(amp;)?id=[^& ]*/i', '', StringUtil::ampersand(Environment::get('request'))) . '&amp;act=paste&amp;mode=cut&amp;table=tl_iso_product&amp;id=' . $row['id'] . '&amp;pid=' . Input::get('id') . '&rt=' . Input::get('rt') . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . ' onclick="Backend.getScrollOffset();">' . Image::getHtml($icon, $label) . '</a> ';
+        return '<a href="' . preg_replace('/&(amp;)?id=[^& ]*/i', '', ampersand(Environment::get('request'))) . '&amp;act=paste&amp;mode=cut&amp;table=tl_iso_product&amp;id=' . $row['id'] . '&amp;pid=' . Input::get('id') . '&rt=' . Input::get('rt') . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . ' onclick="Backend.getScrollOffset();">' . Image::getHtml($icon, $label) . '</a> ';
     }
 
     /**
@@ -276,7 +276,7 @@ class Button extends Backend
         }
 
         return '
-    <a href="' . StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_iso_group', ['fieldType' => 'radio'])) . '" id="groupOperation'.$row['id'].'" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a>
+    <a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_iso_group', ['fieldType' => 'radio'])) . '" id="groupOperation'.$row['id'].'" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a>
     <script>
       document.getElementById("groupOperation'.$row['id'].'").addEventListener("click", function(e) {
         e.preventDefault();
@@ -320,7 +320,7 @@ class Button extends Backend
         Backend.openModalSelector({
           id: "tl_listing",
           title: ' . json_encode($GLOBALS['TL_LANG']['tl_iso_product']['product_groups'][0]) . ',
-          url: '.json_encode(StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_iso_group', ['fieldType' => 'radio'])).\Session::getInstance()->get('iso_products_gid')).',
+          url: '.json_encode(ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_iso_group', ['fieldType' => 'radio'])).\Session::getInstance()->get('iso_products_gid')).',
           callback: function(table, value) {
               new Request.Contao({
               evalScripts: false,

--- a/system/modules/isotope/library/Isotope/Backend/Product/Label.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Label.php
@@ -139,7 +139,7 @@ class Label
             /** @noinspection HtmlUnknownTarget */
             return sprintf(
                 '<a href="%s" title="%s">%s</a>',
-                StringUtil::ampersand(Environment::get('request')) . '&amp;id=' . $row['id'],
+                ampersand(Environment::get('request')) . '&amp;id=' . $row['id'],
                 StringUtil::specialchars($GLOBALS['TL_LANG'][$dc->table]['showVariants']),
                 $objProduct->name
             );

--- a/system/modules/isotope/library/Isotope/Backend/Product/Panel.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Panel.php
@@ -42,7 +42,7 @@ class Panel extends Backend
         // Check if user can manage groups
         if ($user->isAdmin || (\is_array($user->iso_groups) && 0 !== \count($user->iso_groups))) {
             $buttons[] = '
-    <a href="' . StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_iso_group', ['fieldType' => 'radio'])) . '" class="tl_submit'.(!empty($session['iso_products_gid']) ? ' active' : '').'" id="groupFilter">' . $GLOBALS['TL_LANG']['MSC']['filterByGroups'] . '</a>
+    <a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_iso_group', ['fieldType' => 'radio'])) . '" class="tl_submit'.(!empty($session['iso_products_gid']) ? ' active' : '').'" id="groupFilter">' . $GLOBALS['TL_LANG']['MSC']['filterByGroups'] . '</a>
     <script>
       document.getElementById("groupFilter").addEventListener("click", function(e) {
         e.preventDefault();
@@ -62,7 +62,7 @@ class Panel extends Backend
         }
 
         $buttons[] = '
-    <a href="' . StringUtil::ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_page', ['fieldType' => 'radio'])) . '" class="tl_submit'.($intPage > 0 ? ' active' : '').'" id="pageFilter">' . $GLOBALS['TL_LANG']['MSC']['filterByPages'] . '</a>
+    <a href="' . ampersand(System::getContainer()->get('contao.picker.builder')->getUrl('dc.tl_page', ['fieldType' => 'radio'])) . '" class="tl_submit'.($intPage > 0 ? ' active' : '').'" id="pageFilter">' . $GLOBALS['TL_LANG']['MSC']['filterByPages'] . '</a>
     <script>
       document.getElementById("pageFilter").addEventListener("click", function(e) {
         e.preventDefault();

--- a/system/modules/isotope/library/Isotope/Backend/Product/VariantGenerator.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/VariantGenerator.php
@@ -83,12 +83,12 @@ class VariantGenerator extends Backend
 
         return '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=generate', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=generate', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . sprintf($GLOBALS['TL_LANG']['tl_iso_product']['generate'][1], $dc->id) . '</h2>' . Message::generate() . '
 
-<form action="' . StringUtil::ampersand(Environment::get('request'), true) . '" id="tl_iso_product_generate" class="tl_form" method="post">
+<form action="' . ampersand(Environment::get('request'), true) . '" id="tl_iso_product_generate" class="tl_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="tl_iso_product_generate">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">

--- a/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
@@ -546,12 +546,12 @@ class Callback extends Backend
         // Return form
         return '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand($strRedirectUrl) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand($strRedirectUrl) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . sprintf($GLOBALS['TL_LANG']['tl_iso_product_collection']['print_document'][1], $dc->id) . '</h2>' . $strMessages . '
 
-<form action="' . StringUtil::ampersand(Environment::get('request'), true) . '" id="tl_iso_product_import" class="tl_form" method="post">
+<form action="' . ampersand(Environment::get('request'), true) . '" id="tl_iso_product_import" class="tl_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="tl_iso_print_document">
 <input type="hidden" name="REQUEST_TOKEN" value="' . REQUEST_TOKEN . '">

--- a/system/modules/isotope/library/Isotope/Frontend/ProductCollectionAction/ContinueShoppingAction.php
+++ b/system/modules/isotope/library/Isotope/Frontend/ProductCollectionAction/ContinueShoppingAction.php
@@ -13,7 +13,6 @@ namespace Isotope\Frontend\ProductCollectionAction;
 
 use Contao\Input;
 use Contao\Module;
-use Contao\StringUtil;
 use Isotope\Interfaces\IsotopeProductCollection;
 
 class  ContinueShoppingAction extends AbstractLink
@@ -64,6 +63,6 @@ class  ContinueShoppingAction extends AbstractLink
      */
     public function getHref()
     {
-        return StringUtil::ampersand(base64_decode(Input::get('continue', true)));
+        return ampersand(base64_decode(Input::get('continue', true)));
     }
 }

--- a/system/modules/isotope/library/Isotope/Model/Document.php
+++ b/system/modules/isotope/library/Isotope/Model/Document.php
@@ -98,6 +98,6 @@ abstract class Document extends TypeAgent
      */
     protected function sanitizeFileName($strName, $blnPreserveUppercase = true)
     {
-        return StringUtil::standardize(StringUtil::ampersand($strName, false), $blnPreserveUppercase);
+        return StringUtil::standardize(ampersand($strName, false), $blnPreserveUppercase);
     }
 }

--- a/system/modules/isotope/library/Isotope/Model/Payment.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment.php
@@ -349,7 +349,7 @@ abstract class Payment extends TypeAgent implements IsotopePayment
     {
         return '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . $this->name . ' (' . $GLOBALS['TL_LANG']['MODEL']['tl_iso_payment'][$this->type][0] . ')' . '</h2>

--- a/system/modules/isotope/library/Isotope/Model/Payment/Datatrans.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Datatrans.php
@@ -195,9 +195,9 @@ class Datatrans extends Postsale implements IsotopeNotificationTokens, IsotopeBa
             'uppCustomerZipCode'    => $objAddress->postal,
             'uppCustomerPhone'      => $objAddress->phone,
             'uppCustomerEmail'      => $objAddress->email,
-            'successUrl'            => StringUtil::ampersand($successUrl),
-            'errorUrl'              => StringUtil::ampersand(Environment::get('base').Checkout::generateUrlForStep('failed')),
-            'cancelUrl'             => StringUtil::ampersand(Environment::get('base').Checkout::generateUrlForStep('failed')),
+            'successUrl'            => ampersand($successUrl),
+            'errorUrl'              => ampersand(Environment::get('base').Checkout::generateUrlForStep('failed')),
+            'cancelUrl'             => ampersand(Environment::get('base').Checkout::generateUrlForStep('failed')),
             'mod'                   => 'pay',
             'id'                    => $this->id,
         );
@@ -293,7 +293,7 @@ class Datatrans extends Postsale implements IsotopeNotificationTokens, IsotopeBa
 
         $strBuffer = '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . $this->name . ' (' . $GLOBALS['TL_LANG']['MODEL']['tl_iso_payment']['datatrans'][0] . ')' . '</h2>

--- a/system/modules/isotope/library/Isotope/Model/Payment/PSP.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/PSP.php
@@ -372,7 +372,7 @@ abstract class PSP extends Payment implements IsotopePostsale
 
         $buffer = '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . $this->name . ' (' . $GLOBALS['TL_LANG']['MODEL']['tl_iso_payment'][$this->type][0] . ')' . '</h2>

--- a/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/Paypal.php
@@ -225,7 +225,7 @@ class Paypal extends Postsale
 
         $strBuffer = '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . $this->name . ' (' . $GLOBALS['TL_LANG']['MODEL']['tl_iso_payment']['paypal'][0] . ')' . '</h2>

--- a/system/modules/isotope/library/Isotope/Model/Payment/PaypalPlus.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment/PaypalPlus.php
@@ -83,7 +83,7 @@ class PaypalPlus extends PaypalApi
 
         $strBuffer = '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=payment', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>';
 
         foreach ($arrPayment['PAYPAL_HISTORY'] as $response) {

--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -627,7 +627,7 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
         $objTemplate->hasOptions       = \count($arrProductOptions) > 0;
         $objTemplate->enctype          = $this->hasUpload ? 'multipart/form-data' : 'application/x-www-form-urlencoded';
         $objTemplate->formId           = $this->getFormId();
-        $objTemplate->action           = StringUtil::ampersand(Environment::get('request') ?: Environment::get('base'), true);
+        $objTemplate->action           = ampersand(Environment::get('request') ?: Environment::get('base'), true);
         $objTemplate->formSubmit       = $this->getFormId();
         $objTemplate->product_id       = $this->getProductId();
         $objTemplate->module_id        = $arrConfig['module']->id;

--- a/system/modules/isotope/library/Isotope/Model/Shipping.php
+++ b/system/modules/isotope/library/Isotope/Model/Shipping.php
@@ -327,7 +327,7 @@ abstract class Shipping extends TypeAgent implements IsotopeShipping, WeightAggr
     {
         return '
 <div id="tl_buttons">
-<a href="' . StringUtil::ampersand(str_replace('&key=shipping', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
+<a href="' . ampersand(str_replace('&key=shipping', '', Environment::get('request'))) . '" class="header_back" title="' . StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBT']) . '">' . $GLOBALS['TL_LANG']['MSC']['backBT'] . '</a>
 </div>
 
 <h2 class="sub_headline">' . $this->name . ' (' . $GLOBALS['TL_LANG']['MODEL']['tl_iso_shipping'][$this->type][0] . ')' . '</h2>

--- a/system/modules/isotope/library/Isotope/Module/AddressBook.php
+++ b/system/modules/isotope/library/Isotope/Module/AddressBook.php
@@ -144,8 +144,8 @@ class AddressBook extends Module
                     'id'                => $objAddress->id,
                     'class'             => ($objAddress->isDefaultBilling ? 'default_billing' : '') . ($objAddress->isDefaultShipping ? ' default_shipping' : ''),
                     'text'              => $objAddress->generate(),
-                    'edit_url'          => StringUtil::ampersand($strUrl . '?act=edit&address=' . $objAddress->id),
-                    'delete_url'        => StringUtil::ampersand($strUrl . '?act=delete&address=' . $objAddress->id),
+                    'edit_url'          => ampersand($strUrl . '?act=edit&address=' . $objAddress->id),
+                    'delete_url'        => ampersand($strUrl . '?act=delete&address=' . $objAddress->id),
                     'default_billing'   => $objAddress->isDefaultBilling ? true : false,
                     'default_shipping'  => $objAddress->isDefaultShipping ? true : false,
                 ));
@@ -164,7 +164,7 @@ class AddressBook extends Module
         $this->Template->deleteAddressLabel   = $GLOBALS['TL_LANG']['MSC']['deleteAddressLabel'];
         $this->Template->deleteAddressConfirm = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['deleteAddressConfirm']);
         $this->Template->addresses            = $arrAddresses;
-        $this->Template->addNewAddress        = StringUtil::ampersand($strUrl . '?act=create');
+        $this->Template->addNewAddress        = ampersand($strUrl . '?act=create');
     }
 
 

--- a/system/modules/isotope/library/Isotope/Module/CategoryFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/CategoryFilter.php
@@ -94,7 +94,7 @@ class CategoryFilter extends AbstractProductFilter implements IsotopeFilterModul
 
         $allIds = [];
 
-        $this->Template->request = StringUtil::ampersand(Environment::get('indexFreeRequest'));
+        $this->Template->request = ampersand(Environment::get('indexFreeRequest'));
         $this->Template->skipId = 'skipNavigation' . $this->id;
         $this->Template->skipNavigation = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['skipNavigation']);
         $this->Template->items = $this->renderFilterTree($trail[$level], 1, $currentIds, $trail, $allIds);

--- a/system/modules/isotope/library/Isotope/Module/Checkout.php
+++ b/system/modules/isotope/library/Isotope/Module/Checkout.php
@@ -141,7 +141,7 @@ class Checkout extends Module
         $arrBuffer = array();
 
         // Default template settings. Must be set at beginning so they can be overwritten later (eg. trough callback)
-        $this->Template->action        = StringUtil::ampersand(Environment::get('request'));
+        $this->Template->action        = ampersand(Environment::get('request'));
         $this->Template->formId        = $this->strFormId;
         $this->Template->formSubmit    = $this->strFormId;
         $this->Template->enctype       = 'application/x-www-form-urlencoded';

--- a/system/modules/isotope/library/Isotope/Module/CumulativeFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/CumulativeFilter.php
@@ -130,7 +130,7 @@ class CumulativeFilter extends AbstractProductFilter implements IsotopeFilterMod
 
         $this->generateFilter();
 
-        $this->Template->linkClearAll  = StringUtil::ampersand(preg_replace('/\?.*/', '', Environment::get('request')));
+        $this->Template->linkClearAll  = ampersand(preg_replace('/\?.*/', '', Environment::get('request')));
         $this->Template->labelClearAll = $GLOBALS['TL_LANG']['MSC']['clearFiltersLabel'];
     }
 

--- a/system/modules/isotope/library/Isotope/Module/ProductFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/ProductFilter.php
@@ -178,8 +178,8 @@ class ProductFilter extends AbstractProductFilter implements IsotopeFilterModule
 
         $this->Template->id          = $this->id;
         $this->Template->formId      = 'iso_filter_' . $this->id;
-        $this->Template->action      = StringUtil::ampersand(Url::removeQueryString($arrParams));
-        $this->Template->actionClear = StringUtil::ampersand(strtok(Environment::get('request'), '?'));
+        $this->Template->action      = ampersand(Url::removeQueryString($arrParams));
+        $this->Template->actionClear = ampersand(strtok(Environment::get('request'), '?'));
         $this->Template->clearLabel  = $GLOBALS['TL_LANG']['MSC']['clearFiltersLabel'];
         $this->Template->slabel      = $GLOBALS['TL_LANG']['MSC']['submitLabel'];
     }

--- a/system/modules/isotope/library/Isotope/Module/RangeFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/RangeFilter.php
@@ -13,7 +13,6 @@ namespace Isotope\Module;
 
 use Contao\Controller;
 use Contao\Environment;
-use Contao\StringUtil;
 use Haste\Input\Input;
 use Haste\Util\Url;
 use Isotope\Interfaces\IsotopeFilterModule;
@@ -143,7 +142,7 @@ class RangeFilter extends AbstractProductFilter implements IsotopeFilterModule
         $this->Template->fields = $fields;
         $this->Template->jsonFields = json_encode($fields);
         $this->Template->formId      = 'iso_filter_' . $this->id;
-        $this->Template->action      = StringUtil::ampersand(Environment::get('request'));
+        $this->Template->action      = ampersand(Environment::get('request'));
         $this->Template->slabel      = $GLOBALS['TL_LANG']['MSC']['submitLabel'];
     }
 

--- a/system/modules/isotope_reports/library/Isotope/Report/Report.php
+++ b/system/modules/isotope_reports/library/Isotope/Report/Report.php
@@ -111,7 +111,7 @@ abstract class Report extends Backend
         $this->Template->setData($this->arrData);
 
         // Filter stuff
-        $this->Template->action = StringUtil::ampersand($this->Environment->request);
+        $this->Template->action = ampersand($this->Environment->request);
         $this->Template->panels = $this->getPanels();
 
         $this->Template->buttons = $this->getButtons();


### PR DESCRIPTION
Isotope uses `StringUtil::ampersand` which is only available since Contao 4.9.22 (https://github.com/contao/contao/pull/3548).