### PR TITLE
Add specified category option to product list module

### DIFF
--- a/system/modules/isotope/dca/tl_module.php
+++ b/system/modules/isotope/dca/tl_module.php
@@ -18,6 +18,7 @@ $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]               = 'i
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]               = 'iso_emptyFilter';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]               = 'iso_tsdisplay';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]               = 'iso_tscheckout';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][]               = 'iso_category_scope';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['iso_productlist']              = '{title_legend},name,headline,type;{config_legend},numberOfItems,perPage,iso_category_scope,iso_list_where,iso_newFilter,iso_filterModules,iso_listingSortField,iso_listingSortDirection;{redirect_legend},iso_link_primary,iso_jump_first,iso_addProductJumpTo,iso_wishlistJumpTo;{reference_legend:hide},defineRoot;{template_legend:hide},customTpl,iso_list_layout,iso_gallery,iso_cols,iso_use_quantity,iso_hide_list,iso_disable_options,iso_includeMessages,iso_emptyMessage,iso_emptyFilter,iso_buttons;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['iso_productvariantlist']       = '{title_legend},name,headline,type;{config_legend},numberOfItems,perPage,iso_category_scope,iso_list_where,iso_newFilter,iso_filterModules,iso_listingSortField,iso_listingSortDirection;{redirect_legend},iso_link_primary,iso_jump_first,iso_addProductJumpTo,iso_wishlistJumpTo;{reference_legend:hide},defineRoot;{template_legend:hide},customTpl,iso_list_layout,iso_gallery,iso_cols,iso_use_quantity,iso_hide_list,iso_disable_options,iso_includeMessages,iso_emptyMessage,iso_emptyFilter,iso_buttons;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
 $GLOBALS['TL_DCA']['tl_module']['palettes']['iso_productreader']            = '{title_legend},name,headline,type;{config_legend},iso_use_quantity,iso_display404Page;{redirect_legend},iso_addProductJumpTo,iso_wishlistJumpTo;{template_legend:hide},customTpl,iso_reader_layout,iso_gallery,iso_disable_options,iso_includeMessages,iso_buttons;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space';
@@ -48,12 +49,13 @@ $GLOBALS['TL_DCA']['tl_module']['palettes']['iso_trustedshops']             = '{
 /**
  * Add subpalettes to tl_module
  */
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_enableLimit']       = 'iso_perPage';
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_emptyMessage']      = 'iso_noProducts';
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_emptyFilter']       = 'iso_noFilter';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_enableLimit']        = 'iso_perPage';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_emptyMessage']       = 'iso_noProducts';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_emptyFilter']        = 'iso_noFilter';
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_tsdisplay_standard'] = 'iso_tsyoffset';
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_tsdisplay_custom']  = 'iso_tsdirection';
-$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_tscheckout']        = 'iso_tsproducts';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_tsdisplay_custom']   = 'iso_tsdirection';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_tscheckout']         = 'iso_tsproducts';
+$GLOBALS['TL_DCA']['tl_module']['subpalettes']['iso_category_scope_specific'] = 'iso_categories';
 
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['navigationTpl']['eval']['includeBlankOption'] = true;
@@ -394,11 +396,20 @@ $GLOBALS['TL_DCA']['tl_module']['fields']['iso_category_scope'] = array
     'exclude'                   => true,
     'inputType'                 => 'radio',
     'default'                   => 'current_category',
-    'options'                   => array('current_category', 'current_and_first_child', 'current_and_all_children', 'parent', 'product', 'article', 'global'),
+    'options'                   => array('current_category', 'current_and_first_child', 'current_and_all_children', 'parent', 'product', 'article', 'global', 'specific'),
     'reference'                 => &$GLOBALS['TL_LANG']['tl_module']['iso_category_scope_ref'],
     'explanation'               => 'iso_category_scope',
-    'eval'                      => array('tl_class'=>'clr w50 w50h', 'helpwizard'=>true),
+    'eval'                      => array('tl_class'=>'clr w50 w50h', 'helpwizard'=>true, 'submitOnChange'=>true),
     'sql'                       => "varchar(64) NOT NULL default ''",
+);
+
+$GLOBALS['TL_DCA']['tl_module']['fields']['iso_categories'] = array
+(
+    'label'                     => &$GLOBALS['TL_LANG']['tl_module']['iso_categories'],
+    'exclude'                   => true,
+    'inputType'                 => 'pageTree',
+    'eval'                      => array('tl_class'=>'clr', 'mandatory'=>true, 'multiple'=>true, 'fieldType'=>'checkbox'),
+    'sql'                       => "blob NULL",
 );
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['iso_list_where'] = array

--- a/system/modules/isotope/languages/en/tl_module.xlf
+++ b/system/modules/isotope/languages/en/tl_module.xlf
@@ -575,6 +575,18 @@
       <trans-unit id="tl_module.iso_category_scope_ref.article.1">
         <source>If you place the module in an article, it will show products assigned to the artilce's partent page, even though if you place the article in another page (e.g. using insert tag).</source>
       </trans-unit>
+      <trans-unit id="tl_module.iso_category_scope_ref.specific.0">
+        <source>Specified categories</source>
+      </trans-unit>
+      <trans-unit id="tl_module.iso_category_scope_ref.specific.1">
+        <source>This will show all products from the chosen categories in the module's settings.</source>
+      </trans-unit>
+      <trans-unit id="tl_module.iso_categories.0">
+        <source>Product categories</source>
+      </trans-unit>
+      <trans-unit id="tl_module.iso_categories.1">
+        <source>Choose the product categories to be displayed in the list.</source>
+      </trans-unit>
       <trans-unit id="tl_module.sortingDirection.ASC">
         <source>ASC</source>
       </trans-unit>

--- a/system/modules/isotope/library/Isotope/Module/Module.php
+++ b/system/modules/isotope/library/Isotope/Module/Module.php
@@ -16,6 +16,7 @@ use Contao\Database;
 use Contao\Date;
 use Contao\Environment;
 use Contao\FrontendUser;
+use Contao\StringUtil;
 use Contao\System;
 use Haste\Frontend\AbstractFrontendModule;
 use Haste\Input\Input;
@@ -203,6 +204,10 @@ abstract class Module extends AbstractFrontendModule
 
             case 'article':
                 $arrCategories = array($GLOBALS['ISO_CONFIG']['current_article']['pid'] ? : $objPage->id);
+                break;
+
+            case 'specific':
+                $arrCategories = StringUtil::deserialize($this->iso_categories, true);
                 break;
 
             case '':


### PR DESCRIPTION
In pretty much every instance where we use the Isotope shop we wanted to list products of a certain category in specific places in the front end. Currently the product list module does not allow to do that. This PR adds such an option:

<img src="https://user-images.githubusercontent.com/4970961/173020172-359c5096-ee36-443a-b606-13ea4a6fe0e3.png" width="313">

_Note:_ I have based this against `2.8` as there is no `2.9` branch yet.