### PR TITLE
Automatically increase an attribute's database field length

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Attribute/RadioButton.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/RadioButton.php
@@ -11,6 +11,7 @@
 
 namespace Isotope\Model\Attribute;
 
+use Contao\StringUtil;
 use Isotope\Interfaces\IsotopeAttributeForVariants;
 
 /**
@@ -42,7 +43,13 @@ class RadioButton extends AbstractAttributeWithOptions implements IsotopeAttribu
         parent::saveToDCA($arrData);
 
         if ('attribute' === $this->optionsSource) {
-            $arrData['fields'][$this->field_name]['sql'] = "varchar(64) NOT NULL default ''";
+            $length = 64;
+
+            array_walk(StringUtil::deserialize($this->options, true), function($option) use (&$length) {
+                $length = max(ceil(mb_strlen($option['value'] ?? '') / 64) * 64, $length);
+            });
+
+            $arrData['fields'][$this->field_name]['sql'] = "varchar($length) NOT NULL default ''";
         } else {
             $arrData['fields'][$this->field_name]['sql'] = 'int(10) NOT NULL default 0';
         }

--- a/system/modules/isotope/library/Isotope/Model/Attribute/SelectMenu.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/SelectMenu.php
@@ -11,6 +11,7 @@
 
 namespace Isotope\Model\Attribute;
 
+use Contao\StringUtil;
 use Isotope\Interfaces\IsotopeAttributeForVariants;
 
 /**
@@ -51,7 +52,13 @@ class SelectMenu extends AbstractAttributeWithOptions implements IsotopeAttribut
             $arrData['fields'][$this->field_name]['sql'] = 'blob NULL';
         } else {
             if ('attribute' === $this->optionsSource) {
-                $arrData['fields'][$this->field_name]['sql'] = "varchar(64) NOT NULL default ''";
+                $length = 64;
+
+                array_walk(StringUtil::deserialize($this->options, true), function($option) use (&$length) {
+                    $length = max(ceil(mb_strlen($option['value'] ?? '') / 64) * 64, $length);
+                });
+
+                $arrData['fields'][$this->field_name]['sql'] = "varchar($length) NOT NULL default ''";
             } else {
                 $arrData['fields'][$this->field_name]['sql'] = 'int(10) NOT NULL default 0';
             }


### PR DESCRIPTION
Currently if you have a select/radio attribute where the options are defined in the attribute itself, the database field that is created for `tl_iso_product` will have a hard coded length of `64`. However, this means that if you define an option with a value _larger_ than 64 characters, it will lead to an exception in the back end when trying to save the product with that option, as it won't fit into the database field.

This PR solves that by increasing the length of the database field (by multiples of 64) dynamically, according to the option's value lengths. For this to apply you will need to update the database yourself though after you have entered all the possible options for your attribute (via the Install Tool or `contao:migrate`).