### PR TITLE
Allow terminal42/contao-fineuploader v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require-dev": {
         "contao/core-bundle": "4.9.*",
         "contao/manager-plugin": "^2.0",
-        "terminal42/contao-fineuploader": "^2.0",
+        "terminal42/contao-fineuploader": "^2.0 || ^3.0",
         "terminal42/contao-changelanguage": "^3.0",
         "petschko/dhl-php-sdk": "dev-master@dev",
         "mpay24/mpay24-php": "^4.0",
@@ -66,7 +66,7 @@
         "contao/tcpdf-bundle": "Required for the standard document type in Contao 4.7+"
     },
     "conflict": {
-        "terminal42/contao-fineuploader": "< 2.0 || >= 3.0",
+        "terminal42/contao-fineuploader": "< 2.0",
         "terminal42/contao-changelanguage": "< 3.0 || >= 4.0",
         "contao/manager-plugin": "<2.0 || >= 3.0",
         "mpay24/mpay24-php": "< 4.0 || >= 5.0"

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "contao/tcpdf-bundle": "Required for the standard document type in Contao 4.7+"
     },
     "conflict": {
-        "terminal42/contao-fineuploader": "< 2.0 || >=4.0",
+        "terminal42/contao-fineuploader": "< 2.0 || >= 4.0",
         "terminal42/contao-changelanguage": "< 3.0 || >= 4.0",
         "contao/manager-plugin": "<2.0 || >= 3.0",
         "mpay24/mpay24-php": "< 4.0 || >= 5.0"

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "contao/tcpdf-bundle": "Required for the standard document type in Contao 4.7+"
     },
     "conflict": {
-        "terminal42/contao-fineuploader": "< 2.0",
+        "terminal42/contao-fineuploader": "< 2.0 || >=4.0",
         "terminal42/contao-changelanguage": "< 3.0 || >= 4.0",
         "contao/manager-plugin": "<2.0 || >= 3.0",
         "mpay24/mpay24-php": "< 4.0 || >= 5.0"


### PR DESCRIPTION
I am not a pro with Composer, so please correct me if I step out of standards in `composer.json`.

Tested:

1. as a field in order conditions form, with multiple uploads allowed, moving to specified folder, and attaching uploaded files in NC notification via attachment tokens
2. as a frontend attribute of a product, with multiple uploads allowed, moving after upload, and renaming per Simple Tokens

Out of the box no breaking changes (if any) were encountered. If anoyone has any custom classes extending from FineUploader v2, those probably need to be rewritten though.