### PR TITLE
Handle case when host matches no roots, and no root with wildcard DNS exists

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend.php
+++ b/system/modules/isotope/library/Isotope/Frontend.php
@@ -145,6 +145,7 @@ class Frontend extends \Contao\Frontend
                 } elseif (isset($arrPages['*'])) {
                     $arrLangs = $arrPages['*']; // Empty domain
                 } else {
+                    // No domain match (see #2347)
                     return $arrFragments;
                 }
 

--- a/system/modules/isotope/library/Isotope/Frontend.php
+++ b/system/modules/isotope/library/Isotope/Frontend.php
@@ -142,8 +142,10 @@ class Frontend extends \Contao\Frontend
                 // Look for a root page whose domain name matches the host name
                 if (isset($arrPages[$strHost])) {
                     $arrLangs = $arrPages[$strHost];
-                } else {
+                } elseif (isset($arrPages['*'])) {
                     $arrLangs = $arrPages['*']; // Empty domain
+                } else {
+                    return $arrFragments;
                 }
 
                 // Use the first result (see #4872)


### PR DESCRIPTION
If all root pages have `dns` set but request host does not match any of them, Contao throws `NotFoundHttpException`. However, if a product reader page is requested, then Isotope breaks this behaviour in PHP 8, failing with

```
TypeError:
current(): Argument #1 ($array) must be of type array, null given

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Frontend.php:151
```