### PR TITLE
Use installer from installation-bundle

### DIFF
--- a/system/modules/isotope/library/Isotope/DatabaseUpdater.php
+++ b/system/modules/isotope/library/Isotope/DatabaseUpdater.php
@@ -12,6 +12,7 @@
 namespace Isotope;
 
 use Contao\Database;
+use Contao\System;
 use Database\Installer;
 
 /**
@@ -27,7 +28,13 @@ class DatabaseUpdater extends Installer
      */
     public function autoUpdateTables($arrTables)
     {
-        $arrCommands = $this->compileCommands();
+        $container = System::getContainer();
+
+        $installer = $container->has('contao_installation.database.installer')
+            ? $container->get('contao_installation.database.installer')
+            : $container->get('contao.installer');
+
+        $arrCommands = $installer->getCommands();
 
         foreach ($arrTables as $strTable) {
 


### PR DESCRIPTION
When autoupdating tables (e.g. when an Attribute's configuration is changed in back end), this now uses installer service from `contao/installation-bundle` instead of legacy `Contao\Database\Installer` (which eventually executed a deprecating method down the line, leading to warnings like `Warning: Undefined array key "precision"` etc.).

This fixes #2343.

NOTE: There's no need now to extend from `Contao\Database\Installer`, should I remove it?

Also, feel free to correct CS if needed.

NOTE 2: the service is called `contao.installer` in `4.9`, but is deprecated in `4.13` and `contao_installation.database.installer` is used instead, hence the `if` check. Probably should leave a comment, please suggest the wording.