### PR TITLE
Restore PHP 7.2, 7.3 compatibility

### DIFF
--- a/system/modules/isotope/drivers/DC_ProductData.php
+++ b/system/modules/isotope/drivers/DC_ProductData.php
@@ -1594,7 +1594,9 @@ class DC_ProductData extends \DC_Table
                             }
 
                             $implode = static function ($v) use (&$implode) {
-                                return implode(', ', array_map(static fn($vv) => \is_array($vv) ? $implode($vv) : $vv, $v));
+                                return implode(', ', array_map(static function($vv) {
+                                    return \is_array($vv) ? $implode($vv) : $vv;
+                                }, $v));
                             };
                             $args[$k] = $implode($args_k);
                         }


### PR DESCRIPTION
`static fn(…) => …` only works in PHP 7.4 or higher - however Isotope is still supposed to be compatible with PHP 7.2.