### PR TITLE
Fix for "Private methods cannot be final as they are never overridden by other classes"

### DIFF
--- a/system/modules/isotope_rules/library/Isotope/Rules.php
+++ b/system/modules/isotope_rules/library/Isotope/Rules.php
@@ -36,7 +36,7 @@ class Rules extends Controller
     /**
      * Prevent cloning of the object (Singleton)
      */
-    final private function __clone() {}
+    private function __clone() {}
 
 
     /**


### PR DESCRIPTION
The following error currently occurs in PHP 8:

```
Warning: Private methods cannot be final as they are never overridden by other classes in vendor/isotope/isotope-core/system/modules/isotope_rules/library/Isotope/Rules.php on line 39
```

Looks like this is not compatible with PHP 8 anymore:

https://github.com/isotope/core/blob/16af192a2be6571d3065c5ef6e4c8bbee78825dd/system/modules/isotope_rules/library/Isotope/Rules.php#L39

https://3v4l.org/2XUIl