### PR TITLE
Fix PHP8 warning

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Config/AddressFieldsWizard.php
+++ b/system/modules/isotope/library/Isotope/Backend/Config/AddressFieldsWizard.php
@@ -89,16 +89,13 @@ class AddressFieldsWizard extends Backend
             if (!($arrDCA[$strName]['eval']['feEditable'] ?? false)) {
                 continue;
             }
-            
-            if(!isset($arrField['eval']['mandatory']))
-            {
-                $arrField['eval']['mandatory'] = false;
-            }
+
+            $mandatory = isset($arrField['eval']['mandatory']) ? $arrField['eval']['mandatory'] : null;
 
             $arrFields[$strName] = array(
                 'name'      => $strName,
-                'billing'   => $arrField['eval']['mandatory'] === true ? 'mandatory' : ($arrField['eval']['mandatory'] === false ? 'enabled' : 'disabled'),
-                'shipping'  => $arrField['eval']['mandatory'] === true ? 'mandatory' : ($arrField['eval']['mandatory'] === false ? 'enabled' : 'disabled'),
+                'billing'   => $mandatory === true ? 'mandatory' : ($mandatory === false ? 'enabled' : 'disabled'),
+                'shipping'  => $mandatory === true ? 'mandatory' : ($mandatory === false ? 'enabled' : 'disabled'),
             );
         }
 

--- a/system/modules/isotope/library/Isotope/Backend/Config/AddressFieldsWizard.php
+++ b/system/modules/isotope/library/Isotope/Backend/Config/AddressFieldsWizard.php
@@ -89,6 +89,11 @@ class AddressFieldsWizard extends Backend
             if (!($arrDCA[$strName]['eval']['feEditable'] ?? false)) {
                 continue;
             }
+            
+            if(!isset($arrField['eval']['mandatory']))
+            {
+                $arrField['eval']['mandatory'] = false;
+            }
 
             $arrFields[$strName] = array(
                 'name'      => $strName,


### PR DESCRIPTION
Contao 4.13.8, PHP 8.1.6. Creating a new store configuration results in the following error: Warning: Undefined array key "mandatory".

This PR fixes this by checking if the 'mandatory' key exists and defaults it to false if not.