### PR TITLE
Make <noscript> text match the submit button

### DIFF
--- a/system/modules/isotope/languages/de/default.xlf
+++ b/system/modules/isotope/languages/de/default.xlf
@@ -523,7 +523,7 @@
       </trans-unit>
       <trans-unit id="MSC.pay_with_redirect.2">
         <source>Pay now</source>
-        <target>Bezahlen</target>
+        <target>Jetzt bezahlen</target>
       </trans-unit>
       <trans-unit id="MSC.pay_with_redirect.3">
         <source>Please click on the &quot;Pay now&quot; button to continue.</source>


### PR DESCRIPTION
The text in the `<noscript>`-block tells the user to click on `Jetzt bezahlen` but the button actually just says `Bezahlen`.