### PR TITLE
Fix 2.7.0, 2.7.1 and 2.8.0 migrations

### DIFF
--- a/system/modules/isotope/library/Isotope/Upgrade/Base.php
+++ b/system/modules/isotope/library/Isotope/Upgrade/Base.php
@@ -29,11 +29,11 @@ abstract class Base extends System
      */
     protected function createDatabaseField($strField, $strTable)
     {
-        if (!Database::getInstance()->tableExists($strTable)) {
+        if (!Database::getInstance()->tableExists($strTable, null, true)) {
             return false;
         }
 
-        if (!\Database::getInstance()->fieldExists($strField, $strTable)) {
+        if (!\Database::getInstance()->fieldExists($strField, $strTable, true)) {
             Database::getInstance()->query("
                 ALTER TABLE $strTable
                 ADD COLUMN `$strField` " . $this->getSqlForField($strField, $strTable)

--- a/system/modules/isotope/library/Isotope/Upgrade/To0020070000.php
+++ b/system/modules/isotope/library/Isotope/Upgrade/To0020070000.php
@@ -35,8 +35,8 @@ class To0020070000 extends Base
 
     private function migrateProductCollectionLog(Database $db)
     {
-        if (!$db->tableExists('tl_iso_product_collection', true)
-            || $db->tableExists('tl_iso_product_collection_log', true)
+        if (!$db->tableExists('tl_iso_product_collection', null, true)
+            || $db->tableExists('tl_iso_product_collection_log', null, true)
         ) {
             return;
         }
@@ -53,19 +53,19 @@ CREATE TABLE tl_iso_product_collection_log (
 ) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = MyISAM
         ");
 
-        $orders = $db->execute("SELECT * FROM tl_iso_product_collection WHERE type='order' AND locked IS NOT NULL");
+        $orders = $db->execute("SELECT * FROM tl_iso_product_collection WHERE type='order' AND locked IS NOT NULL")->fetchAllAssoc();
 
-        while ($orders->next()) {
+        foreach ($orders as $order) {
             $db
                 ->prepare('INSERT INTO tl_iso_product_collection_log %s')
                 ->set([
-                    'pid' => $orders->id,
-                    'tstamp' => $orders->tstamp,
+                    'pid' => $order['id'],
+                    'tstamp' => $order['tstamp'],
                     'data' => json_encode([
-                        'order_status' => $orders->order_status,
-                        'date_paid' => $orders->date_paid,
-                        'date_shipped' => $orders->date_shipped,
-                        'notes' => $orders->notes,
+                        'order_status' => $order['order_status'],
+                        'date_paid' => $order['date_paid'],
+                        'date_shipped' => $order['date_shipped'],
+                        'notes' => $order['notes'],
                     ]),
                 ])
                 ->execute()

--- a/system/modules/isotope/library/Isotope/Upgrade/To0020070001.php
+++ b/system/modules/isotope/library/Isotope/Upgrade/To0020070001.php
@@ -15,36 +15,36 @@ class To0020070001 extends Base
 
     private function migrateProductCollectionLog(Database $db)
     {
-        if (!$db->tableExists('tl_iso_product_collection', true)
-            || !$db->tableExists('tl_iso_product_collection_log', true)
-            || !$db->fieldExists('order_status', 'tl_iso_product_collection_log', true)
+        if (!$db->tableExists('tl_iso_product_collection', null, true)
+            || !$db->tableExists('tl_iso_product_collection_log', null, true)
+            || !$db->fieldExists('order_status', 'tl_iso_product_collection_log', null, true)
         ) {
             return;
         }
 
         $this->createDatabaseField('data', 'tl_iso_product_collection_log');
 
-        $records = $db->execute("SELECT * FROM tl_iso_product_collection_log");
+        $records = $db->execute("SELECT * FROM tl_iso_product_collection_log")->fetchAllAssoc();
 
-        while ($records->next()) {
-            if ($records->data) {
+        foreach ($records as $record) {
+            if ($record['data']) {
                 continue;
             }
 
             $data = [
-                'sendNotification' => $records->sendNotification,
-                'notification_shipping_tracking' => $records->notification_shipping_tracking,
-                'notification_customer_notes' => $records->notification_customer_notes,
-                'notification' => $records->notification,
-                'notes' => $records->notes,
-                'date_shipped' => $records->date_shipped,
-                'date_paid' => $records->date_paid,
-                'order_status' => $records->order_status,
+                'sendNotification' => $record['sendNotification'],
+                'notification_shipping_tracking' => $record['notification_shipping_tracking'],
+                'notification_customer_notes' => $record['notification_customer_notes'],
+                'notification' => $record['notification'],
+                'notes' => $record['notes'],
+                'date_shipped' => $record['date_shipped'],
+                'date_paid' => $record['date_paid'],
+                'order_status' => $record['order_status'],
             ];
 
             $db
                 ->prepare("UPDATE tl_iso_product_collection_log SET data=? WHERE id=?")
-                ->execute(json_encode($data), $records->id)
+                ->execute(json_encode($data), $record['id'])
             ;
         }
 

--- a/system/modules/isotope/library/Isotope/Upgrade/To0020080000.php
+++ b/system/modules/isotope/library/Isotope/Upgrade/To0020080000.php
@@ -12,7 +12,7 @@ class To0020080000 extends Base
             return;
         }
 
-        if (Database::getInstance()->fieldExists('iso_setReaderJumpTo', 'tl_page') && $this->createDatabaseField('iso_readerMode', 'tl_page')) {
+        if (Database::getInstance()->fieldExists('iso_setReaderJumpTo', 'tl_page', true) && $this->createDatabaseField('iso_readerMode', 'tl_page')) {
             Database::getInstance()->execute("UPDATE tl_page SET iso_readerMode='page' WHERE iso_setReaderJumpTo='1'");
         }
     }


### PR DESCRIPTION
This fixes various issues with the 2.7.0, 2.7.1 and 2.8.0 migrations. Errors that can occur currently are:

* `Cannot execute queries while other unbuffered queries are active.`
* `Table 'tl_iso_product_collection_log' already exists.`
* `Field 'iso_readerMode' already exists.`

The former is fixed by calling `fetchAllAssoc` on the result, otherwise this error can occur in Contao 4.9.0+ because the result is buffered.

The latter two issues are fixed by setting `$blnNoCache` to `true` for the respective methods (`fieldExists` and `tableExists`). Within the 2.7.0 and 2.7.1 migrations this was probably the intention anyway - however the boolean was set for the wrong argument so far.

For the `2.8.0` migration fix I changed `Base::createDatabaseField` to also use `true` for the `$blnNoCache` parameter.