### PR TITLE
Null check for missing meta data keys

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
@@ -399,8 +399,8 @@ class Standard extends Gallery implements IsotopeGallery
             $arrFile[$strType . '_imageSize'] = $arrSize;
         }
 
-        $arrFile['alt']     = StringUtil::specialchars($arrFile['alt'], true);
-        $arrFile['desc']    = StringUtil::specialchars($arrFile['desc'], true);
+        $arrFile['alt']     = StringUtil::specialchars(($arrFile['alt'] ??''), true);
+        $arrFile['desc']    = StringUtil::specialchars(($arrFile['desc'] ?? ''), true);
         $arrFile['picture'] = $picture;
 
         $arrFile[$strType] = TL_ASSETS_URL . $strImage;

--- a/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
@@ -399,8 +399,8 @@ class Standard extends Gallery implements IsotopeGallery
             $arrFile[$strType . '_imageSize'] = $arrSize;
         }
 
-        $arrFile['alt']     = StringUtil::specialchars(($arrFile['alt'] ??''), true);
-        $arrFile['desc']    = StringUtil::specialchars(($arrFile['desc'] ?? ''), true);
+        $arrFile['alt']     = StringUtil::specialchars($arrFile['alt'] ?? '', true);
+        $arrFile['desc']    = StringUtil::specialchars($arrFile['desc'] ?? '', true);
         $arrFile['picture'] = $picture;
 
         $arrFile[$strType] = TL_ASSETS_URL . $strImage;


### PR DESCRIPTION
Fix for these errors. (Also submitted as Issue #2380)

[17-Oct-2022 14:31:02 UTC] PHP Warning: Undefined array key "alt" in /home/sapwebsite/public_html/vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php on line 402
[17-Oct-2022 14:31:02 UTC] PHP Warning: Undefined array key "desc" in /home/sapwebsite/public_html/vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php on line 403