### PR TITLE
Fix PHP 8 warning

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php
@@ -294,7 +294,7 @@ class Standard extends Gallery implements IsotopeGallery
 
             case 'lightbox':
                 $arrFile = $this->getImageForType('lightbox', $arrFile, $blnWatermark);
-                [$link, $rel] = explode('|', $arrFile['link'], 2);
+                [$link, $rel] = explode('|', $arrFile['link'], 2) + [null, null];
                 $attributes = ($rel ? ' data-lightbox="' . $rel . '"' : ' target="_blank"');
 
                 $objTemplate->hasLink    = true;


### PR DESCRIPTION
Fixes the following warning:

```
ErrorException:
Warning: Undefined array key 1

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Model/Gallery/Standard.php:297
```