### PR TITLE
Fix the legacy registered hooks being overwritten by the annotation ones

### DIFF
--- a/system/modules/isotope/library/Isotope/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/system/modules/isotope/library/Isotope/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Isotope\DependencyInjection\Compiler;
 
-use Contao\CoreBundle\EventListener\GlobalsMapListener;
+use Isotope\EventListener\RegisterHooksListener;
 use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,7 +29,7 @@ class RegisterHookListenersPass implements CompilerPassInterface
             $hooks[$hook] = array_merge(...$hooks[$hook]);
         }
 
-        $listener = new Definition(GlobalsMapListener::class, [['ISO_HOOKS' => $hooks]]);
+        $listener = new Definition(RegisterHooksListener::class, [$hooks]);
         $listener->setPublic(true);
         $listener->addTag('contao.hook', ['hook' => 'initializeSystem', 'priority' => 255]);
 

--- a/system/modules/isotope/library/Isotope/DependencyInjection/Compiler/RegisterHookListenersPass.php
+++ b/system/modules/isotope/library/Isotope/DependencyInjection/Compiler/RegisterHookListenersPass.php
@@ -26,7 +26,6 @@ class RegisterHookListenersPass implements CompilerPassInterface
         // Sort the listeners by priority
         foreach (array_keys($hooks) as $hook) {
             krsort($hooks[$hook]);
-            $hooks[$hook] = array_merge(...$hooks[$hook]);
         }
 
         $listener = new Definition(RegisterHooksListener::class, [$hooks]);

--- a/system/modules/isotope/library/Isotope/EventListener/RegisterHooksListener.php
+++ b/system/modules/isotope/library/Isotope/EventListener/RegisterHooksListener.php
@@ -7,19 +7,26 @@ class RegisterHooksListener
     /**
      * @var array
      */
-    private $hooks;
+    private $hookListeners;
 
-    public function __construct(array $hooks)
+    public function __construct(array $hookListeners)
     {
-        $this->hooks = $hooks;
+        $this->hookListeners = $hookListeners;
     }
 
-    public function onInitializeSystem(): void
+    public function __invoke(): void
     {
-        if (isset($GLOBALS['ISO_HOOKS']) && \is_array($GLOBALS['ISO_HOOKS'])) {
-            $GLOBALS['ISO_HOOKS'] = array_merge_recursive($GLOBALS['ISO_HOOKS'], $this->hooks);
-        } else {
-            $GLOBALS['ISO_HOOKS'] = $this->hooks;
+        foreach ($this->hookListeners as $hookName => $priorities) {
+            if (isset($GLOBALS['ISO_HOOKS'][$hookName]) && \is_array($GLOBALS['ISO_HOOKS'][$hookName])) {
+                if (isset($priorities[0])) {
+                    $priorities[0] = array_merge($GLOBALS['ISO_HOOKS'][$hookName], $priorities[0]);
+                } else {
+                    $priorities[0] = $GLOBALS['ISO_HOOKS'][$hookName];
+                    krsort($priorities);
+                }
+            }
+
+            $GLOBALS['ISO_HOOKS'][$hookName] = array_merge(...$priorities);
         }
     }
 }

--- a/system/modules/isotope/library/Isotope/EventListener/RegisterHooksListener.php
+++ b/system/modules/isotope/library/Isotope/EventListener/RegisterHooksListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Isotope\EventListener;
+
+class RegisterHooksListener
+{
+    /**
+     * @var array
+     */
+    private $hooks;
+
+    public function __construct(array $hooks)
+    {
+        $this->hooks = $hooks;
+    }
+
+    public function onInitializeSystem(): void
+    {
+        if (isset($GLOBALS['ISO_HOOKS']) && \is_array($GLOBALS['ISO_HOOKS'])) {
+            $GLOBALS['ISO_HOOKS'] = array_merge_recursive($GLOBALS['ISO_HOOKS'], $this->hooks);
+        } else {
+            $GLOBALS['ISO_HOOKS'] = $this->hooks;
+        }
+    }
+}


### PR DESCRIPTION
If you have any hooks that are registered in the legacy way:

```php
// config/config.php
$GLOBALS['ISO_HOOKS']['generateProduct'][] = […];
```

They will get overwritten if there is at least one hook registered with annotations:

```php
use Isotope\ServiceAnnotation\IsotopeHook;

/**
 * @IsotopeHook("generateProduct")
 */
class MyListener {
    // …
}
```

This pull request aims to fix that.