### PR TITLE
Fix php8 warnings: Undefined array key

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Attribute.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute.php
@@ -512,7 +512,7 @@ abstract class Attribute extends TypeAgent implements IsotopeAttribute
     <tr>';
 
         foreach (array_keys($arrValues[0]) as $i => $name) {
-            if ($arrFormat[$name]['doNotShow']) {
+            if ($arrFormat[$name]['doNotShow'] ?? null) {
                 continue;
             }
 
@@ -534,11 +534,11 @@ abstract class Attribute extends TypeAgent implements IsotopeAttribute
             $c = -1;
 
             foreach ($row as $name => $value) {
-                if ($arrFormat[$name]['doNotShow']) {
+                if ($arrFormat[$name]['doNotShow'] ?? null) {
                     continue;
                 }
 
-                if ('price' === $arrFormat[$name]['rgxp']) {
+                if ('price' === $arrFormat[$name]['rgxp'] ?? null) {
                     $intTax = (int) $row['tax_class'];
 
                     $value = Isotope::formatPriceWithCurrency(Isotope::calculatePrice($value, $objProduct, $this->field_name, $intTax));

--- a/system/modules/isotope/library/Isotope/Model/Attribute/AbstractAttributeWithOptions.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/AbstractAttributeWithOptions.php
@@ -327,7 +327,7 @@ abstract class AbstractAttributeWithOptions extends Attribute implements Isotope
 
         if (($options['product'] ?? null) instanceof IsotopeProduct) {
             $product = $options['product'];
-        } elseif (($item = $options['item']) instanceof ProductCollectionItem && $item->hasProduct()) {
+        } elseif (($item = ($options['item'] ?? null)) instanceof ProductCollectionItem && $item->hasProduct()) {
             $product = $item->getProduct();
         }
 

--- a/system/modules/isotope/library/Isotope/Model/Attribute/PriceTiers.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/PriceTiers.php
@@ -52,7 +52,7 @@ class PriceTiers extends Attribute
             );
         }
 
-        $order = $arrOptions['order'];
+        $order = $arrOptions['order'] ?? '';
         if ($order != '' && \in_array($order, array_keys($arrTiers[0]))) {
 
             usort($arrTiers, function ($a, $b) use ($order) {

--- a/system/modules/isotope/library/Isotope/Module/AbstractProductFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/AbstractProductFilter.php
@@ -262,6 +262,6 @@ abstract class AbstractProductFilter extends Module
             return (array) ($cache['variant_attributes'][$attributeName] ?? null);
         }
 
-        return (array) $cache['attributes'][$attributeName];
+        return (array) ($cache['attributes'][$attributeName] ?? null);
     }
 }


### PR DESCRIPTION
fixed some php 8 warnings I ran into will testing. All warnings are "Undefined array key xxx"