### PR TITLE
Fix various PHP 8 issues under Contao 4.13

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend.php
+++ b/system/modules/isotope/library/Isotope/Frontend.php
@@ -654,10 +654,18 @@ class Frontend extends \Contao\Frontend
 
         // Define the static URL constants
         $isDebugMode = System::getContainer()->getParameter('kernel.debug');
-        \define('TL_FILES_URL', ($objPage->staticFiles != '' && !$isDebugMode) ? $objPage->staticFiles . TL_PATH . '/' : '');
-        \define('TL_ASSETS_URL', ($objPage->staticPlugins != '' && !$isDebugMode) ? $objPage->staticPlugins . TL_PATH . '/' : '');
-        \define('TL_SCRIPT_URL', TL_ASSETS_URL);
-        \define('TL_PLUGINS_URL', TL_ASSETS_URL);
+        if (!\defined('TL_FILES_URL')) {
+            \define('TL_FILES_URL', ($objPage->staticFiles != '' && !$isDebugMode) ? $objPage->staticFiles . TL_PATH . '/' : '');
+        }
+        if (!\defined('TL_ASSETS_URL')) {
+            \define('TL_ASSETS_URL', ($objPage->staticPlugins != '' && !$isDebugMode) ? $objPage->staticPlugins . TL_PATH . '/' : '');
+        }
+        if (!\defined('TL_SCRIPT_URL')) {
+            \define('TL_SCRIPT_URL', TL_ASSETS_URL);
+        }
+        if (!\defined('TL_PLUGINS_URL')) {
+            \define('TL_PLUGINS_URL', TL_ASSETS_URL);
+        }
 
         $objLayout = Database::getInstance()->prepare("
             SELECT l.*, t.templates
@@ -673,7 +681,7 @@ class Frontend extends \Contao\Frontend
             $objPage->templateGroup = $objLayout->templates;
 
             // Store the output format
-            [$strFormat, $strVariant] = explode('_', $objLayout->doctype);
+            [$strFormat, $strVariant] = explode('_', $objLayout->doctype) + [null, null];
             $objPage->outputFormat  = $strFormat;
             $objPage->outputVariant = $strVariant;
         }

--- a/system/modules/isotope/library/Isotope/Model/Document/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Document/Standard.php
@@ -167,8 +167,6 @@ class Standard extends Document implements IsotopeDocument
      */
     protected function generateTemplate(IsotopeProductCollection $objCollection, array $arrTokens)
     {
-        $objPage = PageModel::findWithDetails($objCollection->page_id);
-
         /** @var Template|\stdClass $objTemplate */
         $objTemplate = new Template($this->documentTpl);
         $objTemplate->setData($this->arrData);
@@ -176,10 +174,9 @@ class Standard extends Document implements IsotopeDocument
         $objTemplate->title         = StringUtil::parseSimpleTokens($this->documentTitle, $arrTokens);
         $objTemplate->collection    = $objCollection;
         $objTemplate->config        = $objCollection->getConfig();
-        $objTemplate->page          = $objPage;
-        $objTemplate->dateFormat    = !empty($objPage->dateFormat) ? $objPage->dateFormat : $GLOBALS['TL_CONFIG']['dateFormat'];
-        $objTemplate->timeFormat    = !empty($objPage->timeFormat) ? $objPage->timeFormat : $GLOBALS['TL_CONFIG']['timeFormat'];
-        $objTemplate->datimFormat   = !empty($objPage->datimFormat) ? $objPage->datimFormat : $GLOBALS['TL_CONFIG']['datimFormat'];
+        $objTemplate->dateFormat    = $GLOBALS['TL_CONFIG']['dateFormat'];
+        $objTemplate->timeFormat    = $GLOBALS['TL_CONFIG']['timeFormat'];
+        $objTemplate->datimFormat   = $GLOBALS['TL_CONFIG']['datimFormat'];
 
         // Render the collection
         $objCollectionTemplate = new Template($this->collectionTpl);

--- a/system/modules/isotope/library/Isotope/Model/Document/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Document/Standard.php
@@ -177,9 +177,9 @@ class Standard extends Document implements IsotopeDocument
         $objTemplate->collection    = $objCollection;
         $objTemplate->config        = $objCollection->getConfig();
         $objTemplate->page          = $objPage;
-        $objTemplate->dateFormat    = $objPage->dateFormat ?: $GLOBALS['TL_CONFIG']['dateFormat'];
-        $objTemplate->timeFormat    = $objPage->timeFormat ?: $GLOBALS['TL_CONFIG']['timeFormat'];
-        $objTemplate->datimFormat   = $objPage->datimFormat ?: $GLOBALS['TL_CONFIG']['datimFormat'];
+        $objTemplate->dateFormat    = !empty($objPage->dateFormat) ? $objPage->dateFormat : $GLOBALS['TL_CONFIG']['dateFormat'];
+        $objTemplate->timeFormat    = !empty($objPage->timeFormat) ? $objPage->timeFormat : $GLOBALS['TL_CONFIG']['timeFormat'];
+        $objTemplate->datimFormat   = !empty($objPage->datimFormat) ? $objPage->datimFormat : $GLOBALS['TL_CONFIG']['datimFormat'];
 
         // Render the collection
         $objCollectionTemplate = new Template($this->collectionTpl);


### PR DESCRIPTION
Fixes the following issues:

```
ErrorException:
Warning: Constant TL_FILES_URL already defined

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Frontend.php:650
  at Isotope\Frontend::loadPageConfig(object(PageModel))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Frontend.php:605)
  at Isotope\Frontend::loadOrderEnvironment(object(Order))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductCollection\Callback.php:515)
  at Isotope\Backend\ProductCollection\Callback->printDocument(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:446)
  at Contao\Backend->getBackendModule('iso_orders', null)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
```
```
ErrorException:
Warning: Undefined array key 1

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Frontend.php:677
  at Isotope\Frontend::loadPageConfig(object(PageModel))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Frontend.php:605)
  at Isotope\Frontend::loadOrderEnvironment(object(Order))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductCollection\Callback.php:515)
  at Isotope\Backend\ProductCollection\Callback->printDocument(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:446)
  at Contao\Backend->getBackendModule('iso_orders', null)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
```
```
ErrorException:
Warning: Attempt to read property "dateFormat" on null

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Model\Document\Standard.php:180
  at Isotope\Model\Document\Standard->generateTemplate(object(Order), array(…))
     (vendor\inspiredminds\contao-isotope-pdf-templates\src\Isotope\Model\Document\Template.php:102)
  at InspiredMinds\ContaoIsotopePdfTemplatesBundle\Isotope\Model\Document\Template->generatePDF(object(Order), array(…))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Model\Document\Standard.php:37)
  at Isotope\Model\Document\Standard->outputToBrowser(object(Order))
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductCollection\Callback.php:523)
  at Isotope\Backend\ProductCollection\Callback->printDocument(object(DC_Table))
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:446)
  at Contao\Backend->getBackendModule('iso_orders', null)
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
```