### PR TITLE
Fix undefined array key in CategoryFilter

### DIFF
--- a/system/modules/isotope/library/Isotope/Module/CategoryFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/CategoryFilter.php
@@ -86,7 +86,7 @@ class CategoryFilter extends AbstractProductFilter implements IsotopeFilterModul
         }
 
         $currentIds = [];
-        $filter = Isotope::getRequestCache()->getFiltersForModules([$this->id])[0];
+        $filter = Isotope::getRequestCache()->getFiltersForModules([$this->id])[0] ?? null;
 
         if ($filter instanceof \Isotope\RequestCache\CategoryFilter) {
             $currentIds = $filter['value'];


### PR DESCRIPTION
Fixes the following:

```
ErrorException:
Warning: Undefined array key 0

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Module\CategoryFilter.php:89
```