### PR TITLE
Fix PHP 8 warnings for regular backend users

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php
@@ -79,7 +79,8 @@ class DcaManager extends Backend
         $intGroup = (int) Session::getInstance()->get('iso_products_gid');
 
         if (!$intGroup) {
-            $intGroup = BackendUser::getInstance()->isAdmin ? 0 : (int) BackendUser::getInstance()->iso_groups[0];
+            $objUser = BackendUser::getInstance();
+            $intGroup = ($objUser->isAdmin || empty($objUser->iso_groups)) ? 0 : (int) $objUser->iso_groups[0];
         }
 
         $objGroup = Group::findByPk($intGroup);

--- a/system/modules/isotope/library/Isotope/Backend/Product/Permission.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Permission.php
@@ -76,19 +76,19 @@ class Permission extends Backend
             }
         } else {
             // Maybe another function has already set allowed product IDs
-            if (\is_array($GLOBALS['TL_DCA']['tl_iso_product']['list']['sorting']['root'])) {
+            if (\is_array($GLOBALS['TL_DCA']['tl_iso_product']['list']['sorting']['root'] ?? null)) {
                 $arrProducts = array_intersect($GLOBALS['TL_DCA']['tl_iso_product']['list']['sorting']['root'], $arrProducts);
             }
 
             $GLOBALS['TL_DCA']['tl_iso_product']['list']['sorting']['root'] = $arrProducts;
 
             // Set allowed product IDs (edit multiple)
-            if (\is_array($session['CURRENT']['IDS'])) {
+            if (\is_array($session['CURRENT']['IDS'] ?? null)) {
                 $session['CURRENT']['IDS'] = array_intersect($session['CURRENT']['IDS'], $GLOBALS['TL_DCA']['tl_iso_product']['list']['sorting']['root']);
             }
 
             // Set allowed clipboard IDs
-            if (\is_array($session['CLIPBOARD']['tl_iso_product']['id'])) {
+            if (\is_array($session['CLIPBOARD']['tl_iso_product']['id'] ?? null)) {
                 $session['CLIPBOARD']['tl_iso_product']['id'] = array_intersect($session['CLIPBOARD']['tl_iso_product']['id'], $GLOBALS['TL_DCA']['tl_iso_product']['list']['sorting']['root'], Database::getInstance()->query("SELECT id FROM tl_iso_product WHERE pid=0")->fetchEach('id'));
 
                 if (empty($session['CLIPBOARD']['tl_iso_product']['id'])) {


### PR DESCRIPTION
I've got some new warnings, that are triggered for regular backend users, but not for admins.

When a user lists products in backend:

```
ErrorException:
Warning: Undefined array key "root"

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Backend/Product/Permission.php:79
  at Isotope\Backend\Product\Permission::check(object(ProductData))
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:201)
  at Contao\DC_Table->__construct('tl_iso_product')
     (vendor/isotope/isotope-core/system/modules/isotope/drivers/DC_ProductData.php:89)
  at DC_ProductData->__construct('tl_iso_product', array('tables' => array('tl_iso_product', 'tl_iso_group', 'tl_iso_product_category', 'tl_iso_download', 'tl_iso_related_product', 'tl_iso_product_price', 'tl_iso_product_pricetier', 'tl_iso_attribute_option', 'tl_content'), 'javascript' => 'system/modules/isotope/assets/js/backend.js', 'generate' => array('Isotope\\Backend\\Product\\VariantGenerator', 'generate'), 'import' => array('Isotope\\Backend\\Product\\AssetImport', 'generate'), 'fallback' => array('Isotope\\Backend\\Product\\Fallback', 'setFromUrl')))
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:416)
  at Contao\Backend->getBackendModule('iso_products', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:44)
```

When a user tries to add new product:

```
ErrorException:
Warning: Undefined array key 0

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Backend/Product/DcaManager.php:82
  at Isotope\Backend\Product\DcaManager->updateNewRecord('tl_iso_product', '616', array('shipping_weight' => 'a:1:{s:4:"unit";s:2:"kg";}', 'tstamp' => 0), object(ProductData))
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:654)
  at Contao\DC_Table->create()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:667)
  at Contao\Backend->getBackendModule('iso_products', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:44)
```
