### PR TITLE
Fix PHP 8 warning in order conditions form

### DIFF
--- a/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
+++ b/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
@@ -101,7 +101,7 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
 
             $_SESSION['CHECKOUT_DATA'] = \is_array($_SESSION['CHECKOUT_DATA'] ?? null) ? $_SESSION['CHECKOUT_DATA'] : array();
             foreach (array_keys($this->objForm->getFormFields()) as $strField) {
-                if ($this->objForm->getWidget($strField) instanceof \uploadable) {
+                if ($this->objForm->getWidget($strField) instanceof \uploadable && !empty($_SESSION['FILES'][$strField])) {
                     $arrFile  = $_SESSION['FILES'][$strField];
                     $varValue = str_replace(TL_ROOT . '/', '', \dirname($arrFile['tmp_name'])) . '/' . rawurlencode($arrFile['name']);
                 } else {
@@ -119,7 +119,7 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
 
                 // Clone widget because otherwise we add errors to the original widget instance
                 $objClone = clone $this->objForm->getWidget($strField);
-                if ($objClone instanceof \uploadable) {
+                if ($objClone instanceof \uploadable && !empty($_SESSION['FILES'][$strField])) {
                     $_FILES[$strField] = $_SESSION['FILES'][$strField];
                 } else {
                     Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField] ?? null);

--- a/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
+++ b/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
@@ -101,9 +101,11 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
 
             $_SESSION['CHECKOUT_DATA'] = \is_array($_SESSION['CHECKOUT_DATA'] ?? null) ? $_SESSION['CHECKOUT_DATA'] : array();
             foreach (array_keys($this->objForm->getFormFields()) as $strField) {
-                if ($this->objForm->getWidget($strField) instanceof \uploadable && !empty($_SESSION['FILES'][$strField])) {
-                    $arrFile  = $_SESSION['FILES'][$strField];
-                    $varValue = str_replace(TL_ROOT . '/', '', \dirname($arrFile['tmp_name'])) . '/' . rawurlencode($arrFile['name']);
+                if ($this->objForm->getWidget($strField) instanceof \uploadable) {
+                    if (isset($_SESSION['FILES'][$strField])) {
+                        $arrFile = $_SESSION['FILES'][$strField];
+                        $varValue = str_replace(TL_ROOT . '/', '', \dirname($arrFile['tmp_name'])) . '/' . rawurlencode($arrFile['name']);
+                    }
                 } else {
                     $varValue = $this->objForm->fetch($strField);
                 }
@@ -120,7 +122,9 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
                 // Clone widget because otherwise we add errors to the original widget instance
                 $objClone = clone $this->objForm->getWidget($strField);
                 if ($objClone instanceof \uploadable) {
-                    $_FILES[$strField] = $_SESSION['FILES'][$strField] ?? null;
+                    if (isset($_SESSION['FILES'][$strField])) {
+                        $_FILES[$strField] = $_SESSION['FILES'][$strField];
+                    }
                 } else {
                     Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField] ?? null);
                 }

--- a/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
+++ b/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
@@ -119,8 +119,8 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
 
                 // Clone widget because otherwise we add errors to the original widget instance
                 $objClone = clone $this->objForm->getWidget($strField);
-                if ($objClone instanceof \uploadable && !empty($_SESSION['FILES'][$strField])) {
-                    $_FILES[$strField] = $_SESSION['FILES'][$strField];
+                if ($objClone instanceof \uploadable) {
+                    $_FILES[$strField] = $_SESSION['FILES'][$strField] ?? null;
                 } else {
                     Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField] ?? null);
                 }

--- a/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
+++ b/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php
@@ -105,6 +105,8 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
                     if (isset($_SESSION['FILES'][$strField])) {
                         $arrFile = $_SESSION['FILES'][$strField];
                         $varValue = str_replace(TL_ROOT . '/', '', \dirname($arrFile['tmp_name'])) . '/' . rawurlencode($arrFile['name']);
+                    } else {
+                        $varValue = null;
                     }
                 } else {
                     $varValue = $this->objForm->fetch($strField);
@@ -122,9 +124,7 @@ class OrderConditions extends CheckoutStep implements IsotopeCheckoutStep, Isoto
                 // Clone widget because otherwise we add errors to the original widget instance
                 $objClone = clone $this->objForm->getWidget($strField);
                 if ($objClone instanceof \uploadable) {
-                    if (isset($_SESSION['FILES'][$strField])) {
-                        $_FILES[$strField] = $_SESSION['FILES'][$strField];
-                    }
+                    $_FILES[$strField] = $_SESSION['FILES'][$strField] ?? null;
                 } else {
                     Input::setPost($strField, $_SESSION['CHECKOUT_DATA'][$strField] ?? null);
                 }


### PR DESCRIPTION
If order conditions form contains file upload field which is not mandatory, there will be a warning when the form is displayed:

```
ErrorException:
Warning: Undefined array key "FILES"

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php:123
  at Isotope\CheckoutStep\OrderConditions->generate()
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Module/Checkout.php:325)
```

and later – when it is submitted:

```
ErrorException:
Warning: Undefined array key "FILES"

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/CheckoutStep/OrderConditions.php:105
```