### PR TITLE
Allow getGallery to use different Isotope Galleries

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -516,8 +516,9 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
         $currentGallery          = null;
         $objTemplate->getGallery = function ($strAttribute, $galleryId=null) use ($objProduct, $arrConfig, &$currentGallery) {
             
-            if(!is_null($isoGalleryId))
-                $arrConfig['gallery'] = $isoGalleryId;
+            if(!is_null($isoGalleryId)) {
+                $arrConfig['gallery'] = $galleryId;
+            }
             
             if (null === $currentGallery
                 || $currentGallery->getName() !== $objProduct->getFormId() . '_' . $strAttribute

--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -514,8 +514,11 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
 
         /** @var StandardGallery $currentGallery */
         $currentGallery          = null;
-        $objTemplate->getGallery = function ($strAttribute) use ($objProduct, $arrConfig, &$currentGallery) {
-
+        $objTemplate->getGallery = function ($strAttribute, $isoGalleryId=null) use ($objProduct, $arrConfig, &$currentGallery) {
+            
+            if(!is_null($isoGalleryId))
+                $arrConfig['gallery'] = $isoGalleryId;
+            
             if (null === $currentGallery
                 || $currentGallery->getName() !== $objProduct->getFormId() . '_' . $strAttribute
             ) {

--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -512,14 +512,17 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
             return $objPrice->generate($objType->showPriceTiers(), 1, $objProduct->getOptions());
         };
 
-        /** @var StandardGallery $currentGallery */
-        $currentGallery          = null;
-        $objTemplate->getGallery = function ($strAttribute, $galleryId=null) use ($objProduct, $arrConfig, &$currentGallery) {
-            
-            if(!is_null($galleryId)) {
+        /** @var StandardGallery|null $currentGallery */
+        $currentGallery = null;
+        $objTemplate->getGallery = static function (string $strAttribute, int $galleryId = null) use ($objProduct, $arrConfig, &$currentGallery) {
+            if ($galleryId) {
                 $arrConfig['gallery'] = $galleryId;
+
+                if ($currentGallery && $currentGallery->id != $galleryId) {
+                    $currentGallery = null;
+                }
             }
-            
+
             if (null === $currentGallery
                 || $currentGallery->getName() !== $objProduct->getFormId() . '_' . $strAttribute
             ) {

--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -514,7 +514,7 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
 
         /** @var StandardGallery $currentGallery */
         $currentGallery          = null;
-        $objTemplate->getGallery = function ($strAttribute, $isoGalleryId=null) use ($objProduct, $arrConfig, &$currentGallery) {
+        $objTemplate->getGallery = function ($strAttribute, $galleryId=null) use ($objProduct, $arrConfig, &$currentGallery) {
             
             if(!is_null($isoGalleryId))
                 $arrConfig['gallery'] = $isoGalleryId;

--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -516,7 +516,7 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
         $currentGallery          = null;
         $objTemplate->getGallery = function ($strAttribute, $galleryId=null) use ($objProduct, $arrConfig, &$currentGallery) {
             
-            if(!is_null($isoGalleryId)) {
+            if(!is_null($galleryId)) {
                 $arrConfig['gallery'] = $galleryId;
             }
             


### PR DESCRIPTION
We have a Product Reader page where we have multiple galleries being displayed. We wanted the ability to pick a different Isotope Gallery (Store configuration > Galleries) so I've added to getGallery a second parameter which is null by default but can be the ID of which gallery you want. Below that, if the ID is detected it replaces the current on inside $arrConfig.

I've tested this and it works perfectly. Feel free to change to any style you'd like, but for a three line change this adds very helpful functionality.