### PR TITLE
Fix unknown array key exception

### DIFF
--- a/system/modules/isotope/library/Isotope/Upgrade/To0020070000.php
+++ b/system/modules/isotope/library/Isotope/Upgrade/To0020070000.php
@@ -77,6 +77,7 @@ CREATE TABLE tl_iso_product_collection_log (
     {
         if (!$db->tableExists('tl_module')
             || !$db->fieldExists('iso_order_conditions', 'tl_module')
+            || !$db->fieldExists('iso_order_conditions_position', 'tl_module')
         ) {
             return;
         }


### PR DESCRIPTION
After updating from [2.8.12](https://github.com/isotope/core/tree/2.8.12) to [2.8.13](https://github.com/isotope/core/tree/2.8.13) I got an unknown array key exception when running the contao migration. I don't exactly know if the upgrade code for 2.7.x is supposed to run when performing the described update, but it ran regardless and caused an error. To work around the issue I used this patch. If anybody knows if this upgrade step is supposed to run or what might have caused it to run fell free to explain or theorize. I don't know if this patch is something that should be merged, but just in case here is the PR.