### PR TITLE
Update OrderConditionFields.php

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Module/OrderConditionFields.php
+++ b/system/modules/isotope/library/Isotope/Backend/Module/OrderConditionFields.php
@@ -86,7 +86,7 @@ class OrderConditionFields extends \Backend
             $groupLabel = $GLOBALS['TL_LANG']['MSC']['checkout_'.$group];
 
             foreach ($steps as $step) {
-                $options[$groupLabel][$step] = $GLOBALS['TL_LANG']['CHECKOUT'][$step] ?: substr($step, strrpos($step, '\\') + 1);
+                $options[$groupLabel][$step] = $GLOBALS['TL_LANG']['CHECKOUT'][$step] ?? substr($step, strrpos($step, '\\') + 1);
             }
         }
 


### PR DESCRIPTION
In Backend`dev`mode, editing an `Isotope checkout module` throws errors: 
```
Warning: Undefined array key "\Isotope\CheckoutStep\BillingAddress"
```
Contao: 4.13.24
Isotope:  2.8.14