### PR TITLE
Prevent "class not available" error (Adaption towards Contao 5 Step 002)

### DIFF
--- a/system/modules/isotope/library/Isotope/Interfaces/IsotopeProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Interfaces/IsotopeProductCollection.php
@@ -16,7 +16,7 @@ use Haste\Units\Mass\Scale;
 use Isotope\Model\Config;
 use Isotope\Model\ProductCollectionItem;
 use Isotope\Model\ProductCollectionSurcharge;
-use Isotope\Template;
+use Contao\Template;
 
 
 /**

--- a/system/modules/isotope/library/Isotope/Interfaces/IsotopeProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Interfaces/IsotopeProductCollection.php
@@ -16,6 +16,7 @@ use Haste\Units\Mass\Scale;
 use Isotope\Model\Config;
 use Isotope\Model\ProductCollectionItem;
 use Isotope\Model\ProductCollectionSurcharge;
+use Isotope\Template;
 
 
 /**
@@ -248,10 +249,10 @@ interface IsotopeProductCollection
     /**
      * Add the collection to a template
      *
-     * @param \Template $objTemplate
+     * @param Template $objTemplate
      * @param array     $arrConfig
      */
-    public function addToTemplate(\Template $objTemplate, array $arrConfig = []);
+    public function addToTemplate(Template $objTemplate, array $arrConfig = []);
 
     /**
      * Add an error message


### PR DESCRIPTION
Next adaption towards Contao 5.

See useCases tested with cypress: [tests](https://github.com/Ernestopheles/isotopeDemo/tree/cypress/cypress)
Contao 4.13.31, Isotope 2.9 and PHP 8.1