### PR TITLE
Get rid of array_insert function (Adaption to Contao5 Step 005)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "hashids/hashids": "^4.1"
     },
     "require-dev": {
-        "contao/core-bundle": "4.13.*",
         "contao/manager-plugin": "^2.0",
         "terminal42/contao-fineuploader": "^2.0 || ^3.0",
         "terminal42/contao-changelanguage": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require":{
         "php": "^7.4 || ^8.0",
         "composer-runtime-api": "^2",
-        "contao/core-bundle": "^4.9",
+        "contao/core-bundle": "^4.13",
         "contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
         "terminal42/contao-conditionalselectmenu":"^3.0.3 || ^4.0",
         "terminal42/dcawizard": "^2.3",
@@ -52,7 +52,7 @@
         "hashids/hashids": "^4.1"
     },
     "require-dev": {
-        "contao/core-bundle": "4.9.*",
+        "contao/core-bundle": "4.13.*",
         "contao/manager-plugin": "^2.0",
         "terminal42/contao-fineuploader": "^2.0 || ^3.0",
         "terminal42/contao-changelanguage": "^3.0",

--- a/system/modules/isotope/config/config.php
+++ b/system/modules/isotope/config/config.php
@@ -9,15 +9,17 @@
  * @license    https://opensource.org/licenses/lgpl-3.0.html
  */
 
+use Contao\ArrayUtil;
+
 /**
  * Backend modules
  */
 if (!\is_array($GLOBALS['BE_MOD']['isotope'] ?? null))
 {
-    array_insert($GLOBALS['BE_MOD'], 1, array('isotope' => array()));
+    ArrayUtil::arrayInsert($GLOBALS['BE_MOD'], 1, array('isotope' => array()));
 }
 
-array_insert($GLOBALS['BE_MOD']['isotope'], 0, array
+ArrayUtil::arrayInsert($GLOBALS['BE_MOD']['isotope'], 0, array
 (
     'iso_products' => array
     (

--- a/system/modules/isotope_reports/config/config.php
+++ b/system/modules/isotope_reports/config/config.php
@@ -9,10 +9,12 @@
  * @license    https://opensource.org/licenses/lgpl-3.0.html
  */
 
+ use Contao\ArrayUtil;
+
 /**
  * Backend modules
  */
-array_insert($GLOBALS['BE_MOD']['isotope'], 2, array
+ArrayUtil::arrayInsert($GLOBALS['BE_MOD']['isotope'], 2, array
 (
     'reports' => array
     (

--- a/system/modules/isotope_rules/config/config.php
+++ b/system/modules/isotope_rules/config/config.php
@@ -9,10 +9,12 @@
  * @license    https://opensource.org/licenses/lgpl-3.0.html
  */
 
+ use Contao\ArrayUtil;
+
 /**
  * Backend modules
  */
-array_insert($GLOBALS['BE_MOD']['isotope'], 2, array
+ArrayUtil::arrayInsert($GLOBALS['BE_MOD']['isotope'], 2, array
 (
     'iso_rules' => array
     (
@@ -39,7 +41,7 @@ $GLOBALS['TL_MODELS'][\Isotope\Model\Rule::getTable()] = 'Isotope\Model\Rule';
  * Checkout Steps
  * @todo this will no longer work
  */
-array_insert($GLOBALS['ISO_CHECKOUT_STEPS']['review'], 0, array(array('Isotope\Rules', 'cleanRuleUsages')));
+ArrayUtil::arrayInsert($GLOBALS['ISO_CHECKOUT_STEPS']['review'], 0, array(array('Isotope\Rules', 'cleanRuleUsages')));
 
 
 /**

--- a/system/modules/isotope_rules/library/Isotope/Module/Coupons.php
+++ b/system/modules/isotope_rules/library/Isotope/Module/Coupons.php
@@ -11,7 +11,6 @@
 
 namespace Isotope\Module;
 
-use Isotope\CompatibilityHelper;
 use Contao\Controller;
 use Contao\Environment;
 use Contao\Input;

--- a/system/modules/isotope_rules/library/Isotope/Module/Coupons.php
+++ b/system/modules/isotope_rules/library/Isotope/Module/Coupons.php
@@ -11,6 +11,7 @@
 
 namespace Isotope\Module;
 
+use Isotope\CompatibilityHelper;
 use Contao\Controller;
 use Contao\Environment;
 use Contao\Input;


### PR DESCRIPTION
Next adaption towards Contao 5.

See useCases tested with cypress: [tests](https://github.com/Ernestopheles/isotopeDemo/tree/cypress/cypress)
Contao 4.13.31, Isotope 2.9 and PHP 8.1