### PR TITLE
Fix warnings in `DC_ProductData`

### DIFF
--- a/system/modules/isotope/drivers/DC_ProductData.php
+++ b/system/modules/isotope/drivers/DC_ProductData.php
@@ -2231,7 +2231,12 @@ class DC_ProductData extends \DC_Table
 
                             foreach ($row_v as $option)
                             {
-                                $args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?: $option;
+                                if (!\is_string($option))
+                                {
+                                    continue;
+                                }
+
+                                $args_k[] = $GLOBALS['TL_DCA'][$table]['fields'][$v]['reference'][$option] ?? $option;
                             }
 
                             $args[$k] = implode(', ', $args_k);


### PR DESCRIPTION
If you install the official Isotope demo and then edit the variants of a product in the back end (in `dev`), the following error will occur:

```ErrorException:
Warning: Undefined array key "reference"

  at isotope\vendor\isotope\isotope-core\system\modules\isotope\drivers\DC_ProductData.php:2234
  at DC_ProductData->parentView()
     (isotope\vendor\isotope\isotope-core\system\modules\isotope\drivers\DC_ProductData.php:174)
  at DC_ProductData->showAll()
     (isotope\vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:667)
  at Contao\Backend->getBackendModule('iso_products', null)
     (isotope\vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (isotope\vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (isotope\vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (isotope\vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (isotope\vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (isotope\public\index.php:44)    
```

After fixing this one, the following error will occur:

```
ErrorException:
Warning: Array to string conversion

  at isotope\vendor\isotope\isotope-core\system\modules\isotope\drivers\DC_ProductData.php:2237
  at DC_ProductData->parentView()
     (isotope\vendor\isotope\isotope-core\system\modules\isotope\drivers\DC_ProductData.php:174)
  at DC_ProductData->showAll()
     (isotope\vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:667)
  at Contao\Backend->getBackendModule('iso_products', null)
     (isotope\vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (isotope\vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (isotope\vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (isotope\vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (isotope\vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (isotope\public\index.php:44)         
```

May be this needs to be fixed somewhere else though? `$options` will be an array containing the infos of the product variant here.