### PR TITLE
Fix error in product price callback

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductPrice/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductPrice/Callback.php
@@ -26,7 +26,10 @@ class Callback extends Backend
     public function initializeDCA()
     {
         // Set default tax class
-        $GLOBALS['TL_DCA']['tl_iso_product_price']['fields']['tax_class']['default'] = (int) \Isotope\Model\TaxClass::findFallback()->id;
+        if ($taxClass = \Isotope\Model\TaxClass::findFallback())
+        {
+            $GLOBALS['TL_DCA']['tl_iso_product_price']['fields']['tax_class']['default'] = (int) $taxClass->id;
+        }
     }
 
 


### PR DESCRIPTION
When editing price tiers in the official Isotope demo, the following error will occur (in `dev`):

```
ErrorException:
Warning: Attempt to read property "id" on null

  at isotope\vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductPrice\Callback.php:29
  at Isotope\Backend\ProductPrice\Callback->initializeDCA(object(DC_Table))
     (isotope\vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:201)
  at Contao\DC_Table->__construct('tl_iso_product_price', array('tables' => array('tl_iso_product', 'tl_iso_group', 'tl_iso_product_category', 'tl_iso_download', 'tl_iso_related_product', 'tl_iso_product_price', 'tl_iso_product_pricetier', 'tl_iso_attribute_option'), 'javascript' => 'system/modules/isotope/assets/js/backend.js', 'generate' => array('Isotope\\Backend\\Product\\VariantGenerator', 'generate'), 'import' => array('Isotope\\Backend\\Product\\AssetImport', 'generate'), 'fallback' => array('Isotope\\Backend\\Product\\Fallback', 'setFromUrl')))
     (isotope\vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:416)
  at Contao\Backend->getBackendModule('iso_products', null)
     (isotope\vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (isotope\vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (isotope\vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (isotope\vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (isotope\vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (isotope\public\index.php:44)   
```

This PR fixes that.