### PR TITLE
Fix Unsupported operand types exception

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionItem.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionItem.php
@@ -339,7 +339,7 @@ class ProductCollectionItem extends Model
      */
     public function getTotalPrice()
     {
-        return (string) ($this->getPrice() * (int) $this->quantity);
+        return (string) ((float)$this->getPrice() * (int) $this->quantity);
     }
 
     /**
@@ -349,7 +349,7 @@ class ProductCollectionItem extends Model
      */
     public function getTotalOriginalPrice()
     {
-        return (string) ($this->getOriginalPrice() * (int) $this->quantity);
+        return (string) ((float)$this->getOriginalPrice() * (int) $this->quantity);
     }
 
     /**
@@ -359,7 +359,7 @@ class ProductCollectionItem extends Model
      */
     public function getTaxFreeTotalPrice()
     {
-        return (string) ($this->getTaxFreePrice() * (int) $this->quantity);
+        return (string) ((float)$this->getTaxFreePrice() * (int) $this->quantity);
     }
 
     /**


### PR DESCRIPTION
This PR fix the "Unsupported operand types" exception that appears if an product is added to cart (or cart is viewed) when the product has not price attribute. 

This PR adds just a float cast to the price calculation methods in `ProductCollectionItem`, so the price calculation methods always return a price :)