### PR TITLE
Check `previousStep` for `null`

### DIFF
--- a/system/modules/isotope/library/Isotope/Frontend/ProductCollectionAction/AbstractButton.php
+++ b/system/modules/isotope/library/Isotope/Frontend/ProductCollectionAction/AbstractButton.php
@@ -45,6 +45,6 @@ abstract class AbstractButton implements ProductCollectionActionInterface
      */
     public function handleSubmit(IsotopeProductCollection $collection)
     {
-        return '' !== (string) Input::post('button_' . $this->getName());
+        return null !== Input::post('button_' . $this->getName());
     }
 }

--- a/system/modules/isotope/library/Isotope/Module/AbstractProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Module/AbstractProductCollection.php
@@ -305,7 +305,7 @@ abstract class AbstractProductCollection extends Module
 
         if (null !== $action
             && Input::post('FORM_SUBMIT') === $this->strFormId
-            && '' !== (string) Input::post('button_' . $name)
+            && null !== Input::post('button_' . $name)
         ) {
             if (\is_string($action)) {
                 Controller::redirect($action);

--- a/system/modules/isotope/library/Isotope/Module/Checkout.php
+++ b/system/modules/isotope/library/Isotope/Module/Checkout.php
@@ -393,7 +393,7 @@ class Checkout extends Module
         }
 
         // User pressed "back" button
-        if (\strlen(Input::post('previousStep'))) {
+        if (null !== Input::post('previousStep')) {
             $this->redirectToPreviousStep();
         } // Valid input data, redirect to next step
         elseif (Input::post('FORM_SUBMIT') == $this->strFormId && !$this->doNotSubmit) {

--- a/system/modules/isotope/library/Isotope/Module/Favorites.php
+++ b/system/modules/isotope/library/Isotope/Module/Favorites.php
@@ -106,7 +106,7 @@ class Favorites extends AbstractProductCollection
 
         // Add all items to cart based on quantity field and global button
         if (Input::post('FORM_SUBMIT') === $this->strFormId
-            && '' !== (string) Input::post('button_add_to_cart')
+            && null !== (string) Input::post('button_add_to_cart')
             && (0 === \count($quantity) || $quantity[$item->id] > 0)
         ) {
             Isotope::getCart()->addProduct(


### PR DESCRIPTION
Currently a click on the back button within the checkout module might not be recognized if the value of the button is empty for whatever reason, e.g. if you adjusted the template to

```html
<button type="submit" class="submit previous button" name="previousStep"></button>
```

for example, or if the `previousLabel` variable is empty for whatever reason. A click on the back button in this case will instead be interpreted as a click on the confirm/next button. This PR changes that by always checking whether the back button was used - by way of checking if `Input::post` returns null or not.