### PR TITLE
Remove type from model constructor argument

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Address.php
+++ b/system/modules/isotope/library/Isotope/Model/Address.php
@@ -66,7 +66,7 @@ class Address extends Model
      *
      * @param Result $objResult
      */
-    public function __construct(Result $objResult = null)
+    public function __construct($objResult = null)
     {
         parent::__construct($objResult);
 

--- a/system/modules/isotope/library/Isotope/Model/Address.php
+++ b/system/modules/isotope/library/Isotope/Model/Address.php
@@ -64,7 +64,7 @@ class Address extends Model
     /**
      * Construct the model
      *
-     * @param Result $objResult
+     * @param Result|array $objResult An optional database result or array
      */
     public function __construct($objResult = null)
     {

--- a/system/modules/isotope/library/Isotope/Model/Attribute/BasePrice.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/BasePrice.php
@@ -25,7 +25,7 @@ class BasePrice extends Attribute
     /**
      * @inheritdoc
      */
-    public function __construct(Result $objResult = null)
+    public function __construct($objResult = null)
     {
         // This class should not be registered
         // Set type or ModelType would throw an exception

--- a/system/modules/isotope/library/Isotope/Model/Attribute/BasePrice.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/BasePrice.php
@@ -11,7 +11,6 @@
 
 namespace Isotope\Model\Attribute;
 
-use Contao\Database\Result;
 use Contao\StringUtil;
 use Isotope\Interfaces\IsotopeProduct;
 use Isotope\Isotope;

--- a/system/modules/isotope/library/Isotope/Model/Attribute/Price.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/Price.php
@@ -26,7 +26,7 @@ class Price extends Attribute implements IsotopeAttributeWithRange
     /**
      * @inheritdoc
      */
-    public function __construct(\Database\Result $objResult = null)
+    public function __construct($objResult = null)
     {
         // This class should not be registered
         // Set type or ModelType would throw an exception

--- a/system/modules/isotope/library/Isotope/Model/Attribute/PriceTiers.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/PriceTiers.php
@@ -22,7 +22,7 @@ class PriceTiers extends Attribute
     /**
      * @inheritdoc
      */
-    public function __construct(\Database\Result $objResult = null)
+    public function __construct($objResult = null)
     {
         // This class should not be registered
         // Set type or ModelType would throw an exception

--- a/system/modules/isotope/library/Isotope/Model/Attribute/ShippingPrice.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/ShippingPrice.php
@@ -25,7 +25,7 @@ class ShippingPrice extends Attribute
     /**
      * @inheritdoc
      */
-    public function __construct(\Database\Result $objResult = null)
+    public function __construct($objResult = null)
     {
         // This class should not be registered
         // Set type or ModelType would throw an exception

--- a/system/modules/isotope/library/Isotope/Model/Attribute/Weight.php
+++ b/system/modules/isotope/library/Isotope/Model/Attribute/Weight.php
@@ -24,7 +24,7 @@ class Weight extends Attribute
     /**
      * @inheritdoc
      */
-    public function __construct(\Database\Result $objResult = null)
+    public function __construct($objResult = null)
     {
         // This class should not be registered
         // Set type or ModelType would throw an exception

--- a/system/modules/isotope/library/Isotope/Model/Payment.php
+++ b/system/modules/isotope/library/Isotope/Model/Payment.php
@@ -85,7 +85,7 @@ abstract class Payment extends TypeAgent implements IsotopePayment
     /**
      * @inheritdoc
      */
-    public function __construct(\Database\Result $objResult = null)
+    public function __construct($objResult = null)
     {
         parent::__construct($objResult);
 

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection.php
@@ -129,7 +129,7 @@ abstract class ProductCollection extends TypeAgent implements IsotopeProductColl
      *
      * @param \Database\Result $objResult
      */
-    public function __construct(\Database\Result $objResult = null)
+    public function __construct($objResult = null)
     {
         parent::__construct($objResult);
 

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection.php
@@ -13,6 +13,7 @@ namespace Isotope\Model;
 
 use Contao\Controller;
 use Contao\Database;
+use Contao\Database\Result;
 use Contao\MemberModel;
 use Contao\StringUtil;
 use Contao\System;
@@ -127,7 +128,7 @@ abstract class ProductCollection extends TypeAgent implements IsotopeProductColl
     /**
      * Constructor
      *
-     * @param \Database\Result $objResult
+     * @param Result|array $objResult An optional database result or array
      */
     public function __construct($objResult = null)
     {

--- a/system/modules/isotope/library/Isotope/Model/ProductPrice.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductPrice.php
@@ -48,7 +48,7 @@ class ProductPrice extends Model implements IsotopePrice
      *
      * @param Result $objResult
      */
-    public function __construct(Result $objResult = null)
+    public function __construct($objResult = null)
     {
         parent::__construct($objResult);
 

--- a/system/modules/isotope/library/Isotope/Model/ProductPrice.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductPrice.php
@@ -46,7 +46,7 @@ class ProductPrice extends Model implements IsotopePrice
     /**
      * Construct the object
      *
-     * @param Result $objResult
+     * @param Result|array $objResult An optional database result or array
      */
     public function __construct($objResult = null)
     {

--- a/system/modules/isotope/library/Isotope/Model/TypeAgent.php
+++ b/system/modules/isotope/library/Isotope/Model/TypeAgent.php
@@ -43,7 +43,7 @@ abstract class TypeAgent extends Model
      *
      * @throws \RuntimeException if model does not have a valid type
      */
-    public function __construct(Result $objResult = null)
+    public function __construct($objResult = null)
     {
         parent::__construct($objResult);
 


### PR DESCRIPTION
Contao's base `\Contao\Model` class has no type on its constructor argument, as it allows both `\Contao\Database\Result` and `array`:

https://github.com/contao/contao/blob/7477d95ccb3cff5f5e315d9163904ebae8f1a0b3/core-bundle/src/Resources/contao/library/Contao/Model.php#L108-L110

This way you can pass an associative array from a database result (e.g. from `doctrine/dbal`) when instantiating a model. However, this is currently not possible with all of the Isotope models as they define the `\Contao\Database\Result` for the constructor argument. This PR fixes that.