### PR TITLE
Fix missing `tstamp`s for order stati

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/OrderStatus/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/OrderStatus/Callback.php
@@ -95,10 +95,12 @@ class Callback extends Backend
         );
 
         $sorting = 0;
+        $time = time();
 
         foreach ($arrStatus as $arrData) {
             $objStatus = new OrderStatus();
             $objStatus->setRow($arrData);
+            $objStatus->tstamp = $time;
             $objStatus->sorting = $sorting;
             $objStatus->save();
 


### PR DESCRIPTION
When installing `isotope/isotope-core` for the first time, the order status back end view will look like this:

<img src="https://github.com/isotope/core/assets/4970961/28ceff89-b0aa-42cf-9bf2-4d9b047f917c" width="397">
&nbsp;

&nbsp;
This is because `tstamp` is `0` for these database records. This PR fixes that.