### PR TITLE
Add `doctrine/dbal` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "composer-runtime-api": "^2",
         "contao/core-bundle": "^4.13",
         "contao-community-alliance/composer-plugin": "^2.4 || ^3.0",
+        "doctrine/dbal": "^3.0",
         "terminal42/contao-conditionalselectmenu":"^3.0.3 || ^4.0",
         "terminal42/dcawizard": "^2.3 || ^3.0",
         "codefog/contao-haste": "^4.24.3",


### PR DESCRIPTION
Isotope uses Doctrine, but has no dependency currently. The dependency needs to be `^3.0` due to the usage of

```
Doctrine\DBAL\Connection::createSchemaManager()
```

for example.