### PR TITLE
Check if attribute model type is registered

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductType/AttributeWizard.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductType/AttributeWizard.php
@@ -169,7 +169,7 @@ class AttributeWizard extends Backend
         /** @var IsotopeAttribute|IsotopeAttributeForVariants $objAttribute */
         $objAttribute = $GLOBALS['TL_DCA']['tl_iso_product']['attributes'][$arrField['name']] ?? null;
 
-        if (!$objAttribute || !$objAttribute->id) {
+        if (null === $objAttribute || !$objAttribute->id) {
             return Image::getHtml('edit_.svg');
         }
 

--- a/system/modules/isotope/library/Isotope/Backend/ProductType/AttributeWizard.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductType/AttributeWizard.php
@@ -169,7 +169,7 @@ class AttributeWizard extends Backend
         /** @var IsotopeAttribute|IsotopeAttributeForVariants $objAttribute */
         $objAttribute = $GLOBALS['TL_DCA']['tl_iso_product']['attributes'][$arrField['name']] ?? null;
 
-        if (!$objAttribute->id) {
+        if (!$objAttribute || !$objAttribute->id) {
             return Image::getHtml('edit_.svg');
         }
 


### PR DESCRIPTION
If you add a custom field to `tl_iso_product` with an `inputType` that does not have a model type registered (e.g. for pure back end purposes), the following error will occur:

```
ErrorException:
Warning: Attempt to read property "id" on null

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\ProductType\AttributeWizard.php:172
  at Isotope\Backend\ProductType\AttributeWizard->getEditButton()
     (vendor\menatwork\contao-multicolumnwizard-bundle\src\Contao\Widgets\MultiColumnWizard.php:1153)
  at MenAtWork\MultiColumnWizardBundle\Contao\Widgets\MultiColumnWizard->initializeWidget()
     (vendor\menatwork\contao-multicolumnwizard-bundle\src\Contao\Widgets\MultiColumnWizard.php:830)
  at MenAtWork\MultiColumnWizardBundle\Contao\Widgets\MultiColumnWizard->generate()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:661)
  at Contao\Widget->generateWithError()
     (vendor\contao\core-bundle\src\Resources\contao\templates\backend\be_widget.html5:3)
  at include('C:\\Users\\fmg\\www\\die-garten-tulln\\vendor\\contao\\core-bundle\\src\\Resources\\contao\\templates\\backend\\be_widget.html5')
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\TemplateInheritance.php:108)
  at Contao\Widget->inherit()
     (vendor\contao\core-bundle\src\Resources\contao\library\Contao\Widget.php:608)
  at Contao\Widget->parse()
     (vendor\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:804)
  at Contao\DataContainer->row()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:1985)
  at Contao\DC_Table->edit()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\BackendModule\BackendOverview.php:245)
  at Isotope\BackendModule\BackendOverview->getModule()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\BackendModule\BackendOverview.php:84)
  at Isotope\BackendModule\BackendOverview->generate()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:439)
  at Contao\Backend->getBackendModule()
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public\index.php:44)                
```

`$objAttribute` can be `null` at this point (see previous line). This PR fixes that by adding an additional check. You can reproduce the issue as follows:

```php
// contao/dca/tl_iso_product.php
use Doctrine\DBAL\Platforms\MySQLPlatform;

$GLOBALS['TL_DCA']['tl_iso_product']['fields']['foobar'] = [
    'inputType' => 'keyValueWizard',
    'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true],
    'attributes' => ['legend' => 'expert_legend', 'systemColumn' => true],
    'sql' => ['type' => 'blob', 'length' => MySQLPlatform::LENGTH_LIMIT_BLOB, 'notnull' => false],
];
```

Then try to edit a product type.