### PR TITLE
Fix warning when using the published toggler for payment methods

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/Payment/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/Payment/Callback.php
@@ -252,7 +252,7 @@ class Callback extends Permission
         $objVersions->initialize();
 
         // Trigger the save_callback
-        if (\is_array($GLOBALS['TL_DCA']['tl_iso_payment']['fields']['enabled']['save_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA']['tl_iso_payment']['fields']['enabled']['save_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA']['tl_iso_payment']['fields']['enabled']['save_callback'] as $callback) {
                 $blnVisible = System::importStatic($callback[0])->{$callback[1]}($blnVisible, $this);
             }


### PR DESCRIPTION
If you use the toggle button in the payment method listing, the following error will occur in debug mode:

```
ErrorException:
Warning: Undefined array key "save_callback"

  at vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\Payment\Callback.php:255
  at Isotope\Backend\Payment\Callback->toggleVisibility()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\Backend\Payment\Callback.php:215)
  at Isotope\Backend\Payment\Callback->toggleIcon()
     (vendor\contao\core-bundle\src\Resources\contao\classes\DataContainer.php:938)
  at Contao\DataContainer->generateButtons()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:5121)
  at Contao\DC_Table->listView()
     (vendor\contao\core-bundle\src\Resources\contao\drivers\DC_Table.php:313)
  at Contao\DC_Table->showAll()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\BackendModule\BackendOverview.php:245)
  at Isotope\BackendModule\BackendOverview->getModule()
     (vendor\isotope\isotope-core\system\modules\isotope\library\Isotope\BackendModule\BackendOverview.php:84)
  at Isotope\BackendModule\BackendOverview->generate()
     (vendor\contao\core-bundle\src\Resources\contao\classes\Backend.php:439)
  at Contao\Backend->getBackendModule()
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor\contao\core-bundle\src\Controller\BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public\index.php:44)           
```