### PR TITLE
Add optional setting to prevent force-show first order column in backend

### DIFF
--- a/system/modules/isotope/drivers/DC_ProductData.php
+++ b/system/modules/isotope/drivers/DC_ProductData.php
@@ -1484,7 +1484,7 @@ class DC_ProductData extends \DC_Table
 <table class="tl_listing' . (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) ? ' showColumns' : '') . ($this->strPickerFieldType ? ' picker unselectable' : '') . '">';
 
             // Automatically add the "order by" field as last column if we do not have group headers
-            if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null)
+            if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && false !== ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? null))
             {
                 $blnFound = false;
 
@@ -2121,7 +2121,7 @@ class DC_ProductData extends \DC_Table
 <table class="tl_listing' . ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ? ' showColumns' : '') . '">';
 
             // Automatically add the "order by" field as last column if we do not have group headers
-            if ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) {
+            if (($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showColumns'] ?? null) && false !== ($GLOBALS['TL_DCA'][$this->strTable]['list']['label']['showFirstOrderBy'] ?? null)) {
                 $blnFound = false;
 
                 // Extract the real key and compare it to $firstOrderBy


### PR DESCRIPTION
This ports https://github.com/contao/contao/pull/6593 to Isotope's data container driver.