### PR TITLE
Use path returned from hook for downloads

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionDownload.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionDownload.php
@@ -131,7 +131,7 @@ class ProductCollectionDownload extends Model
                     }
                 }
 
-                $this->download($objFileModel->path);
+                $this->download($path ?: $objFileModel->path);
             }
 
             $arrMeta = Frontend::getMetaData($objFileModel->meta, $GLOBALS['TL_LANGUAGE']);


### PR DESCRIPTION
The `downloadFromProductCollection` Isotope hook allows the path to be set as the return value - however, the path is then never actually used. This PR fixes that.