### PR TITLE
Use first limit as default in `ProductFilter`

### DIFF
--- a/system/modules/isotope/library/Isotope/Module/ProductFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/ProductFilter.php
@@ -454,9 +454,9 @@ class ProductFilter extends AbstractProductFilter implements IsotopeFilterModule
         if ($this->iso_enableLimit) {
             $arrOptions = [];
             $arrLimit   = array_map('intval', StringUtil::trimsplit(',', $this->iso_perPage));
-            $objLimit   = Isotope::getRequestCache()->getFirstLimitForModules([$this->id]);
             $arrLimit   = array_unique($arrLimit);
             sort($arrLimit);
+            $objLimit   = Isotope::getRequestCache()->getFirstLimitForModules([$this->id], $arrLimit[0] ?? 0);
 
             if ($this->blnUpdateCache && \in_array(Input::post('limit'), $arrLimit)) {
                 // Cache new request value


### PR DESCRIPTION
If you have multiple product or category filters on the page and one of the product filters has `iso_enableLimit` enabled then filtering might not work in general.

What happens is that you are first redirected to e.g. `products?isorc=20` and then back to e.g. `products?isorc=1`, completely ignoring the filter configuration of the request cache ID 20. This can happen if the config ID 20 does not contain a `limit` from the product filter module that has `iso_enableLimit` enabled.

The `ProductFilter` module then thinks the config is wrong and executes:

https://github.com/isotope/core/blob/a23ea30c9a938b71e75fb356c86cba53fda0c7a4/system/modules/isotope/library/Isotope/Module/ProductFilter.php#L466-L474

This then enables `$this->blnUpdateCache = true;` and thus the filter will redirect to another request cache URL.

This PR fixes that by using the first limit value as the default when fetching `getFirstLimitForModules()` from the request cache.