### PR TITLE
Use URL from defined root in category filter

### DIFF
--- a/system/modules/isotope/library/Isotope/Module/CategoryFilter.php
+++ b/system/modules/isotope/library/Isotope/Module/CategoryFilter.php
@@ -208,7 +208,7 @@ class CategoryFilter extends AbstractProductFilter implements IsotopeFilterModul
                 'categoryfilter=' . $value,
                 Url::removeQueryStringCallback(function ($value, $key) {
                     return strpos($key, 'page_iso') !== 0;
-                })
+                }, $this->defineRoot && $this->rootPage > 0 ? $this->rootPage : null)
             );
 
             $row['subitems'] = $subitems;


### PR DESCRIPTION
If you defined a root page in the category filter, the menu will be built according to that root, but the `href` of each item will reference the current page instead of the defined root.

I am not sure this is intended? If not - this PR would fix that by always generating the URL for the defined root instead.