### PR TITLE
Take hash URLs into consideration and fix double ampersand

### DIFF
--- a/system/modules/isotope/templates/modules/mod_iso_productlist_caching.html5
+++ b/system/modules/isotope/templates/modules/mod_iso_productlist_caching.html5
@@ -12,9 +12,11 @@
     (function() {
         Isotope.displayBox('<?= $this->message ?>');
 
-        var url = window.location.href + (document.location.search ? '&' : '?') + '&buildCache=1',
-            xhr = new XMLHttpRequest();
+        var url = window.location.href;
+        url = url.substr(0, url.indexOf(window.location.hash) || url.length);
+        url = url + (document.location.search ? '&' : '?') + 'buildCache=1';
 
+        var xhr = new XMLHttpRequest();
         xhr.open('GET', encodeURI(url));
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 


### PR DESCRIPTION
There are two issues with the current `mod_iso_productlist_caching` template:

#### Hash URLs

If the current URL contains a hash, the current logic will create an URL like this for the AJAX request:

```
https://example.com/products?foobar=1#foobar&&buildCache=1
```

This will result in the `buildCache` parameter being ignored and thus it will only fetch a state where "Loading products ..." is displayed again.

#### Double Ampersand

The current

```js
(document.location.search ? '&' : '?') + '&buildCache=1'
```

results in URLs like 

```
https://example.com/products?foobar=1&&buildCache=1
```

This PR fixes both.