### PR TITLE
Fix missing bracket in `mod_iso_productlist_caching`

### DIFF
--- a/system/modules/isotope/templates/modules/mod_iso_productlist_caching.html5
+++ b/system/modules/isotope/templates/modules/mod_iso_productlist_caching.html5
@@ -16,7 +16,7 @@
         url.searchParams.set('buildCache', '1');
 
         var xhr = new XMLHttpRequest();
-        xhr.open('GET', encodeURI(url.toString());
+        xhr.open('GET', encodeURI(url.toString()));
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
         xhr.onload = function() {


### PR DESCRIPTION
This syntax error was introduced in https://github.com/isotope/core/commit/f3ac4d5f6e75cf7aabb0a358dfca92291e39a7a6