### PR TITLE
Fix product Standard::getVariantIds()

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -261,7 +261,7 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
             $blnHasGuests    = false;
             $isMember = \Contao\System::getContainer()->get('security.helper')->isGranted('ROLE_MEMBER');
             $strQuery        = '
-                SELECT tl_iso_product.id, tl_iso_product.protected, tl_iso_product.groups
+                SELECT tl_iso_product.id, tl_iso_product.protected, tl_iso_product.groups, tl_iso_product.guests
                 FROM tl_iso_product
                 WHERE
                     pid=' . $this->getProductId() . "
@@ -300,12 +300,12 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
                 if ($isMember
                     && $blnHasGuests
                     && $objVariants->guests
-                    && (!$blnHasProtected || $objVariants->protected)
+                    && (!$blnHasProtected || !$objVariants->protected)
                 ) {
                     continue;
                 }
 
-                if ($blnHasProtected && $objVariants->protected) {
+                if ($isMember && $blnHasProtected && $objVariants->protected) {
                     $groups = StringUtil::deserialize($objVariants->groups);
 
                     if (empty($groups) || !\is_array($groups) || !\count(array_intersect($groups, FrontendUser::getInstance()->groups))) {

--- a/system/modules/isotope/library/Isotope/Model/Product/Standard.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/Standard.php
@@ -305,7 +305,7 @@ class Standard extends AbstractProduct implements WeightAggregate, IsotopeProduc
                     continue;
                 }
 
-                if ($isMember && $blnHasProtected && $objVariants->protected) {
+                if ($blnHasProtected && $objVariants->protected) {
                     $groups = StringUtil::deserialize($objVariants->groups);
 
                     if (empty($groups) || !\is_array($groups) || !\count(array_intersect($groups, FrontendUser::getInstance()->groups))) {


### PR DESCRIPTION
- Fix https://github.com/isotope/core/issues/2551 (line 264)
- Fix product variants with guests=1 having protected property not being visible for logged in members having a matching group (line 303)
- Fix runtime error when a protected product variant having guests=1 for guest users (line 308)