### PR TITLE
Add HTTP cache tags

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCache.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCache.php
@@ -15,6 +15,7 @@ use Contao\Database;
 use Contao\FrontendUser;
 use Contao\Input;
 use Contao\Model;
+use Contao\System;
 
 /**
  * Isotope\Model\ProductCache represents an Isotope product cache model
@@ -227,6 +228,10 @@ class ProductCache extends Model
     public static function purge()
     {
         Database::getInstance()->query("TRUNCATE " . static::$strTable);
+
+        if (System::getContainer()->has('fos_http_cache.cache_manager')) {
+            System::getContainer()->get('fos_http_cache.cache_manager')->invalidateTags(['contao.db.tl_iso_product']);
+        }
     }
 
     /**

--- a/system/modules/isotope/library/Isotope/Module/ProductList.php
+++ b/system/modules/isotope/library/Isotope/Module/ProductList.php
@@ -303,6 +303,12 @@ class ProductList extends Module
         ;
 
         $this->Template->products = $arrBuffer;
+
+        // Add cache tag
+        if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger')) {
+            $responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+            $responseTagger->addTags(['contao.db.tl_iso_product']);
+        }
     }
 
     /**

--- a/system/modules/isotope/library/Isotope/Module/ProductReader.php
+++ b/system/modules/isotope/library/Isotope/Module/ProductReader.php
@@ -127,6 +127,12 @@ class ProductReader extends Module
         $this->Template->product_class = $objProduct->getCssClass();
         $this->Template->referer       = 'javascript:history.go(-1)';
         $this->Template->back          = $GLOBALS['TL_LANG']['MSC']['goBack'];
+
+        // Add cache tag
+        if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger')) {
+            $responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+            $responseTagger->addTags(['contao.db.tl_iso_product.'.$objProduct->id]);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, if a page with a product list is in the shared HTTP cache and a new product is added, deleted or a product is changed, the cache will not be invalidated. Likewise if a product detail is in the shared HTTP cache and that product is changed, the shared cache is also not invalidated.

This PR fixes that by adding at least the general `contao.db.tl_iso_product` cache tag for any product list and the `contao.db.tl_iso_product.*` cache tag for any product detail. Both will get automatically invalidated by the `DataContainer` in the back end when editing products.