### PR TITLE
Keep product `auto_item` unused in `AbstractProduct::getCssClass()`

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Product/AbstractProduct.php
+++ b/system/modules/isotope/library/Isotope/Model/Product/AbstractProduct.php
@@ -333,7 +333,7 @@ abstract class AbstractProduct extends Product
             $classes[] = $type->cssClass;
         }
 
-        if ($this->alias === Input::getAutoItem('product')) {
+        if ($this->alias === Input::getAutoItem('product', false, true)) {
             $classes[] = 'active';
         }
 


### PR DESCRIPTION
The `ProductList` retrieves each individual product's CSS class here:

https://github.com/isotope/core/blob/d4c91ed1d7e5552f55d51c3802a3a4bdaf3042ac/system/modules/isotope/library/Isotope/Module/ProductList.php#L281

This causes invalid `auto_item` URLs on the product list page to become valid (i.e. they will not show 404). For example if you have a product list on 

```
https://example.com/shop
```

then the invalid URL

```
https://example.com/shop/not-a-valid-url-parameter
```

will not show the 404 page. Instead it will just show the contents of the `https://example.com/shop` page.

This PR fixes that by enabling the `$blnKeepUnused` parameter.