### PR TITLE
Fix warnings if callbacks are not set

### DIFF
--- a/system/modules/isotope/drivers/DC_TablePageId.php
+++ b/system/modules/isotope/drivers/DC_TablePageId.php
@@ -963,7 +963,7 @@ class DC_TablePageId extends DC_Table
             }
 
             // Call the child_record_callback
-            if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback']))
+            if (\is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null) || \is_callable($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['child_record_callback'] ?? null))
             {
                 $strGroup = '';
                 $blnIndent = false;

--- a/system/modules/isotope/library/Isotope/Backend/Download/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/Download/Callback.php
@@ -194,7 +194,7 @@ class Callback extends Backend
         $objVersions->initialize();
 
         // Trigger the save_callback
-        if (\is_array($GLOBALS['TL_DCA']['tl_iso_download']['fields']['published']['save_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA']['tl_iso_download']['fields']['published']['save_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA']['tl_iso_download']['fields']['published']['save_callback'] as $callback) {
                 $blnVisible = System::importStatic($callback[0])->{$callback[1]}($blnVisible, $this);
             }

--- a/system/modules/isotope/library/Isotope/Backend/Product/Button.php
+++ b/system/modules/isotope/library/Isotope/Backend/Product/Button.php
@@ -365,7 +365,7 @@ class Button extends Backend
         $objVersions->initialize();
 
         // Trigger the save_callback
-        if (\is_array($GLOBALS['TL_DCA']['tl_iso_product']['fields']['published']['save_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA']['tl_iso_product']['fields']['published']['save_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA']['tl_iso_product']['fields']['published']['save_callback'] as $callback) {
                 $blnVisible = System::importStatic($callback[0])->{$callback[1]}($blnVisible, $this);
             }

--- a/system/modules/isotope/library/Isotope/Backend/Shipping/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/Shipping/Callback.php
@@ -216,7 +216,7 @@ class Callback extends Permission
         $objVersions->initialize();
 
         // Trigger the save_callback
-        if (\is_array($GLOBALS['TL_DCA']['tl_iso_shipping']['fields']['enabled']['save_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA']['tl_iso_shipping']['fields']['enabled']['save_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA']['tl_iso_shipping']['fields']['enabled']['save_callback'] as $callback) {
                 $blnVisible = System::importStatic($callback[0])->{$callback[1]}($blnVisible, $this);
             }

--- a/system/modules/isotope/library/Isotope/Module/AddressBook.php
+++ b/system/modules/isotope/library/Isotope/Module/AddressBook.php
@@ -91,7 +91,7 @@ class AddressBook extends Module
         Controller::loadDataContainer($table);
 
         // Call onload_callback (e.g. to check permissions)
-        if (\is_array($GLOBALS['TL_DCA'][$table]['config']['onload_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA'][$table]['config']['onload_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA'][$table]['config']['onload_callback'] as $callback) {
                 System::importStatic($callback[0])->{$callback[1]}();
             }
@@ -237,7 +237,7 @@ class AddressBook extends Module
                 $objAddress->save();
 
                 // Call onsubmit_callback
-                if (\is_array($GLOBALS['TL_DCA'][$table]['config']['onsubmit_callback'])) {
+                if (\is_array($GLOBALS['TL_DCA'][$table]['config']['onsubmit_callback'] ?? null)) {
                     foreach ($GLOBALS['TL_DCA'][$table]['config']['onsubmit_callback'] as $callback) {
                         System::importStatic($callback[0])->{$callback[1]}($objAddress);
                     }

--- a/system/modules/isotope_rules/library/Isotope/Backend/Rule/Callback.php
+++ b/system/modules/isotope_rules/library/Isotope/Backend/Rule/Callback.php
@@ -146,7 +146,7 @@ class Callback extends Backend
 //        $this->createInitialVersion('tl_iso_rule', $intId);
 
         // Trigger the save_callback
-        if (\is_array($GLOBALS['TL_DCA']['tl_iso_rule']['fields']['enabled']['save_callback'])) {
+        if (\is_array($GLOBALS['TL_DCA']['tl_iso_rule']['fields']['enabled']['save_callback'] ?? null)) {
             foreach ($GLOBALS['TL_DCA']['tl_iso_rule']['fields']['enabled']['save_callback'] as $callback) {
                 $objCallback = System::importStatic($callback[0]);
                 $blnVisible = $objCallback->{$callback[1]}($blnVisible, $this);


### PR DESCRIPTION
I initially noticed this problem in AddressBook.php when editing an address in the frontend (see stacktrace below). I have also changed all other places where this problem could occur.

Stacktrace:
```
ErrorException:
Warning: Undefined array key "onsubmit_callback"

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Module/AddressBook.php:240
  at Isotope\Module\AddressBook->edit('...')
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Module/AddressBook.php:107)
  at Isotope\Module\AddressBook->compile()
     (vendor/contao/core-bundle/src/Resources/contao/modules/Module.php:214)
  at Contao\Module->generate()
     (vendor/codefog/contao-haste/library/Haste/Frontend/AbstractFrontendModule.php:52)
  at Haste\Frontend\AbstractFrontendModule->generate()
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Module/Module.php:116)
  at Isotope\Module\Module->generate()
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Module/AddressBook.php:79)
  at Isotope\Module\AddressBook->generate()
     (vendor/contao/core-bundle/src/Resources/contao/elements/ContentModule.php:98)
  at Contao\ContentModule->generate()
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:623)
  at Contao\Controller::getContentElement(object(ContentModel), 'main')
     (vendor/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php:197)
  at Contao\ModuleArticle->compile()
     (vendor/contao/core-bundle/src/Resources/contao/modules/Module.php:214)
  at Contao\Module->generate()
     (vendor/contao/core-bundle/src/Resources/contao/modules/ModuleArticle.php:70)
  at Contao\ModuleArticle->generate(false)
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:551)
  at Contao\Controller::getArticle(object(ArticleModel), false, false, 'main')
     (vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php:393)
  at Contao\Controller::getFrontendModule('0', 'main')
     (vendor/contao/core-bundle/src/Resources/contao/pages/PageRegular.php:194)
  at Contao\PageRegular->prepare(object(PageModel))
     (vendor/contao/core-bundle/src/Resources/contao/pages/PageRegular.php:61)
  at Contao\PageRegular->getResponse(object(PageModel), true)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/FrontendIndex.php:320)
  at Contao\FrontendIndex->renderPage(object(PageModel))
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:44)
```