### PR TITLE
fix floating point error for rule discount

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
@@ -165,7 +165,7 @@ abstract class ProductCollectionSurcharge extends TypeAgent
                 $fltProductPrice = $this->total_price / 100 * (100 / $fltTotal * $objItem->getTaxFreeTotalPrice());
             }
 
-            $fltProductPrice = $fltProductPrice > 0 ? (floor($fltProductPrice * 100) / 100) : (ceil($fltProductPrice * 100) / 100);
+            $fltProductPrice = $fltProductPrice > 0 ? (floor($fltProductPrice * 100) / 100) : (ceil(round($fltProductPrice * 100, 4)) / 100);
 
             $this->setAmountForCollectionItem($fltProductPrice, $objItem);
         }

--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
@@ -165,7 +165,7 @@ abstract class ProductCollectionSurcharge extends TypeAgent
                 $fltProductPrice = $this->total_price / 100 * (100 / $fltTotal * $objItem->getTaxFreeTotalPrice());
             }
 
-            $fltProductPrice = $fltProductPrice > 0 ? (floor($fltProductPrice * 100) / 100) : (ceil(round($fltProductPrice * 100, 4)) / 100);
+            $fltProductPrice = $fltProductPrice > 0 ? (floor(round($fltProductPrice * 100, 4)) / 100) : (ceil(round($fltProductPrice * 100, 4)) / 100);
 
             $this->setAmountForCollectionItem($fltProductPrice, $objItem);
         }

--- a/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollectionSurcharge.php
@@ -165,7 +165,7 @@ abstract class ProductCollectionSurcharge extends TypeAgent
                 $fltProductPrice = $this->total_price / 100 * (100 / $fltTotal * $objItem->getTaxFreeTotalPrice());
             }
 
-            $fltProductPrice = $fltProductPrice > 0 ? (floor(round($fltProductPrice * 100, 4)) / 100) : (ceil(round($fltProductPrice * 100, 4)) / 100);
+            $fltProductPrice = $fltProductPrice > 0 ? (floor($fltProductPrice * 100) / 100) : (ceil($fltProductPrice * 100) / 100);
 
             $this->setAmountForCollectionItem($fltProductPrice, $objItem);
         }

--- a/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
@@ -202,14 +202,14 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
             switch ($objRule->applyTo) {
                 case 'products':
                     $fltPrice = (float) ($blnPercentage ? ($objItem->getTotalPrice() / 100 * $fltDiscount) : $objRule->discount);
-                    $fltPrice = $fltPrice > 0 ? (floor($fltPrice * 100) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
+                    $fltPrice = $fltPrice > 0 ? (floor(round($fltPrice * 100, 4)) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;
 
                 case 'items':
                     $fltPrice = ((float) ($blnPercentage ? ($objItem->getPrice() / 100 * $fltDiscount) : $objRule->discount)) * $objItem->quantity;
-                    $fltPrice = $fltPrice > 0 ? (floor($fltPrice * 100) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
+                    $fltPrice = $fltPrice > 0 ? (floor(round($fltPrice * 100, 4)) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;

--- a/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
@@ -202,14 +202,14 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
             switch ($objRule->applyTo) {
                 case 'products':
                     $fltPrice = (float) ($blnPercentage ? ($objItem->getTotalPrice() / 100 * $fltDiscount) : $objRule->discount);
-                    $fltPrice = $fltPrice > 0 ? (floor(round($fltPrice * 100, 4)) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
+                    $fltPrice = self::calculateDiscount($fltPrice, $objRule->rounding);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;
 
                 case 'items':
                     $fltPrice = ((float) ($blnPercentage ? ($objItem->getPrice() / 100 * $fltDiscount) : $objRule->discount)) * $objItem->quantity;
-                    $fltPrice = $fltPrice > 0 ? (floor(round($fltPrice * 100, 4)) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
+                    $fltPrice = self::calculateDiscount($fltPrice, $objRule->rounding);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;
@@ -248,5 +248,31 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
         }
 
         return $objSurcharge->total_price == 0 ? null : $objSurcharge;
+    }
+
+    private static function calculateDiscount(float $fltDiscount, string $rounding): float {
+
+        $precision = Isotope::getConfig()->priceRoundPrecision;
+        $factor    = 10 ** 2;
+        $up        = $fltDiscount > 0 ? 'ceil' : 'floor';
+        $down      = $fltDiscount > 0 ? 'floor' : 'ceil';
+
+        switch ($rounding) {
+           case RuleModel::ROUND_NORMAL:
+             $fltDiscount = round($fltDiscount, $precision);
+             break;
+
+           case RuleModel::ROUND_UP:
+             $fltDiscount = $up(round($fltDiscount * $factor, 4)) / $factor;
+             break;
+
+           case RuleModel::ROUND_DOWN:
+           default:
+             $fltDiscount = $down(round($fltDiscount * $factor, 4)) / $factor;
+             break;
+        }
+
+        return $fltDiscount;
+
     }
 }

--- a/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
@@ -201,26 +201,24 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
             // Apply To
             switch ($objRule->applyTo) {
                 case 'products':
-                    $fltPrice = (float) ($blnPercentage ? ($objItem->getTotalPrice() / 100 * $fltDiscount) : $objRule->discount);
-                    $fltPrice = self::calculateDiscount($fltPrice, $objRule->rounding);
+                    $fltPrice = $objRule->calculateDiscount($objItem->getTotalPrice());
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;
 
                 case 'items':
-                    $fltPrice = ((float) ($blnPercentage ? ($objItem->getPrice() / 100 * $fltDiscount) : $objRule->discount)) * $objItem->quantity;
-                    $fltPrice = self::calculateDiscount($fltPrice, $objRule->rounding);
+                    $fltPrice = $objRule->calculateDiscount($objItem->getPrice(), (int) $objItem->quantity);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;
 
                 case 'subtotal':
-                    $blnMatch = true;
+                    $blnMatch = true; // At least one item in the collection matched the rule conditions
                     $objSurcharge->total_price += $objItem->getTotalPrice();
 
                     if ($objRule->tax_class == -1) {
                         if ($blnPercentage) {
-                            $fltPrice = $objItem->getTotalPrice() / 100 * $fltDiscount;
+                            $fltPrice = $objRule->calculateDiscount($objItem->getTotalPrice());
                             $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                         } else {
                             $arrSubtract[] = $objItem;
@@ -231,10 +229,9 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
             }
         }
 
-        if ($objRule->applyTo == 'subtotal' && $blnMatch) {
+        if ('subtotal' === $objRule->applyTo && $blnMatch) {
             // discount total! not related to tax subtraction
-            $fltPrice = (float) ($blnPercentage ? ($objSurcharge->total_price / 100 * $fltDiscount) : $objRule->discount);
-            $objSurcharge->total_price = self::calculateDiscount($fltPrice, $objRule->rounding);
+            $objSurcharge->total_price = $objRule->calculateDiscount($objSurcharge->total_price);
             $objSurcharge->before_tax = ($objRule->tax_class != 0 ? true : false);
             $objSurcharge->tax_class = ($objRule->tax_class > 0 ? $objRule->tax_class : 0);
 
@@ -248,31 +245,5 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
         }
 
         return $objSurcharge->total_price == 0 ? null : $objSurcharge;
-    }
-
-    private static function calculateDiscount(float $fltDiscount, string $rounding): float {
-
-        $precision = Isotope::getConfig()->priceRoundPrecision;
-        $factor    = 10 ** 2;
-        $up        = $fltDiscount > 0 ? 'ceil' : 'floor';
-        $down      = $fltDiscount > 0 ? 'floor' : 'ceil';
-
-        switch ($rounding) {
-           case RuleModel::ROUND_NORMAL:
-             $fltDiscount = round($fltDiscount, $precision);
-             break;
-
-           case RuleModel::ROUND_UP:
-             $fltDiscount = $up(round($fltDiscount * $factor, 4)) / $factor;
-             break;
-
-           case RuleModel::ROUND_DOWN:
-           default:
-             $fltDiscount = $down(round($fltDiscount * $factor, 4)) / $factor;
-             break;
-        }
-
-        return $fltDiscount;
-
     }
 }

--- a/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
@@ -202,14 +202,14 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
             switch ($objRule->applyTo) {
                 case 'products':
                     $fltPrice = (float) ($blnPercentage ? ($objItem->getTotalPrice() / 100 * $fltDiscount) : $objRule->discount);
-                    $fltPrice = $fltPrice > 0 ? (floor($fltPrice * 100) / 100) : (ceil($fltPrice * 100) / 100);
+                    $fltPrice = $fltPrice > 0 ? (floor($fltPrice * 100) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;
 
                 case 'items':
                     $fltPrice = ((float) ($blnPercentage ? ($objItem->getPrice() / 100 * $fltDiscount) : $objRule->discount)) * $objItem->quantity;
-                    $fltPrice = $fltPrice > 0 ? (floor($fltPrice * 100) / 100) : (ceil($fltPrice * 100) / 100);
+                    $fltPrice = $fltPrice > 0 ? (floor($fltPrice * 100) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
                     $objSurcharge->total_price += $fltPrice;
                     $objSurcharge->setAmountForCollectionItem($fltPrice, $objItem);
                     break;

--- a/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
@@ -234,7 +234,7 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
         if ($objRule->applyTo == 'subtotal' && $blnMatch) {
             // discount total! not related to tax subtraction
             $fltPrice = (float) ($blnPercentage ? ($objSurcharge->total_price / 100 * $fltDiscount) : $objRule->discount);
-            $objSurcharge->total_price = $fltPrice > 0 ? (floor(round($fltPrice * 100, 4)) / 100) : (ceil(round($fltPrice * 100, 4)) / 100);
+            $objSurcharge->total_price = self::calculateDiscount($fltPrice, $objRule->rounding);
             $objSurcharge->before_tax = ($objRule->tax_class != 0 ? true : false);
             $objSurcharge->tax_class = ($objRule->tax_class > 0 ? $objRule->tax_class : 0);
 

--- a/system/modules/isotope_rules/library/Isotope/Model/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/Rule.php
@@ -116,6 +116,44 @@ class Rule extends Model
         return $this->isPercentage() ? $this->discount : '';
     }
 
+    /**
+     * Calculate discount of a rule. The price argument is (only) necessary to calculate percentage
+     * amounts. Fixed discounts will not be affected by the price given.
+     * Be aware that a discount is usually negative, but also a positive value for a surcharge.
+     *
+     * @param int $quantity Multiply the discount by this value before rounding.
+     */
+    public function calculateDiscount(float $fltPrice, int $quantity = 1): float
+    {
+        if (!$this->isPercentage()) {
+            return $this->discount * $quantity;
+        }
+
+        $fltDiscount = 100 + $this->getPercentage();
+        $fltDiscount = round($fltPrice - ($fltPrice / 100 * $fltDiscount), 10);
+        $fltDiscount = $fltDiscount * $quantity;
+        $precision = Isotope::getConfig()->priceRoundPrecision;
+        $factor = 10 ** 2;
+        $up = $fltDiscount > 0 ? 'ceil' : 'floor';
+        $down = $fltDiscount > 0 ? 'floor' : 'ceil';
+
+        switch ($this->rounding) {
+            case Rule::ROUND_NORMAL:
+                $fltDiscount = round($fltDiscount, $precision);
+                break;
+
+            case Rule::ROUND_UP:
+                $fltDiscount = $up(round($fltDiscount * $factor, 4)) / $factor;
+                break;
+
+            case Rule::ROUND_DOWN:
+            default:
+                $fltDiscount = $down(round($fltDiscount * $factor, 4)) / $factor;
+                break;
+        }
+
+        return $fltDiscount * -1;
+    }
 
     public static function findByProduct(IsotopeProduct $objProduct, $strField, $fltPrice)
     {

--- a/system/modules/isotope_rules/library/Isotope/Rules.php
+++ b/system/modules/isotope_rules/library/Isotope/Rules.php
@@ -106,34 +106,7 @@ class Rules extends Controller
                 continue;
             }
 
-            if ($objRule->isPercentage()) {
-                $fltDiscount = 100 + $objRule->getPercentage();
-                $fltDiscount = round($fltPrice - ($fltPrice / 100 * $fltDiscount), 10);
-
-                $precision = Isotope::getConfig()->priceRoundPrecision;
-                $factor    = 10 ** 2;
-                $up        = $fltDiscount > 0 ? 'ceil' : 'floor';
-                $down      = $fltDiscount > 0 ? 'floor' : 'ceil';
-
-                switch ($objRule->rounding) {
-                    case Rule::ROUND_NORMAL:
-                        $fltDiscount = round($fltDiscount, $precision);
-                        break;
-
-                    case Rule::ROUND_UP:
-                        $fltDiscount = $up(round($fltDiscount * $factor, 4)) / $factor;
-                        break;
-
-                    case Rule::ROUND_DOWN:
-                    default:
-                        $fltDiscount = $down(round($fltDiscount * $factor, 4)) / $factor;
-                        break;
-                }
-
-                $fltPrice = $fltPrice - $fltDiscount;
-            } else {
-                $fltPrice = $fltPrice + $objRule->discount;
-            }
+            $fltPrice += $objRule->calculateDiscount($fltPrice);
         }
 
         return $fltPrice;

--- a/system/modules/isotope_rules/library/Isotope/Rules.php
+++ b/system/modules/isotope_rules/library/Isotope/Rules.php
@@ -72,69 +72,72 @@ class Rules extends Controller
      */
     public function calculatePrice($fltPrice, $objSource, $strField, $intTaxClass)
     {
-        if ($objSource instanceof IsotopePrice && ('price' === $strField || 'low_price' === $strField || 'net_price' === $strField || 'gross_price' === $strField)) {
+        if (!$objSource instanceof IsotopePrice || ('price' !== $strField && 'low_price' !== $strField && 'net_price' !== $strField && 'gross_price' !== $strField)) {
+            return $fltPrice;
+        }
 
         // @todo try not to use getRelated() because it loads variants
         $objRules = Rule::findByProduct($objSource->getRelated('pid'), $strField, $fltPrice);
 
-        if (null !== $objRules) {
-                while ($objRules->next()) {
-                    // Check cart quantity
-                    if ($objRules->minItemQuantity > 0 || $objRules->maxItemQuantity > 0) {
-                        if ('cart_products' === $objRules->quantityMode) {
-                            $intTotal = Isotope::getCart()->countItems();
-                        } elseif ('cart_items' === $objRules->quantityMode) {
-                            $intTotal = Isotope::getCart()->sumItemsQuantity();
-                        } else {
-                            $objItem = Isotope::getCart()->getItemForProduct($objSource->getRelated('pid'));
-                            $intTotal = (null === $objItem) ? 0 : $objItem->quantity;
-                        }
+        if (null === $objRules) {
+            return $fltPrice;
+        }
 
-                        if (($objRules->minItemQuantity > 0 && $objRules->minItemQuantity > $intTotal) || ($objRules->maxItemQuantity > 0 && $objRules->maxItemQuantity < $intTotal)) {
-                            continue;
-                        }
-                    }
-
-                    // We're unable to apply variant price rules to low_price (see #3189)
-                    if ('low_price' === $strField && 'variants' === $objRules->productRestrictions) {
-                        continue;
-                    }
-
-                    if ($objRules->current()->isPercentage()) {
-                        $fltDiscount = 100 + $objRules->current()->getPercentage();
-                        $fltDiscount = round($fltPrice - ($fltPrice / 100 * $fltDiscount), 10);
-
-                        $precision = Isotope::getConfig()->priceRoundPrecision;
-                        $factor    = 10 ** 2;
-                        $up        = $fltDiscount > 0 ? 'ceil' : 'floor';
-                        $down      = $fltDiscount > 0 ? 'floor' : 'ceil';
-
-                        switch ($objRules->rounding) {
-                            case Rule::ROUND_NORMAL:
-                                $fltDiscount = round($fltDiscount, $precision);
-                                break;
-
-                            case Rule::ROUND_UP:
-                                $fltDiscount = $up($fltDiscount * $factor) / $factor;
-                                break;
-
-                            case Rule::ROUND_DOWN:
-                            default:
-                                $fltDiscount = $down($fltDiscount * $factor) / $factor;
-                                break;
-                        }
-
-                        $fltPrice = $fltPrice - $fltDiscount;
-                    } else {
-                        $fltPrice = $fltPrice + $objRules->discount;
-                    }
+        /** @var Rule $objRule */
+        foreach ($objRules as $objRule) {
+            // Check cart quantity
+            if ($objRule->minItemQuantity > 0 || $objRule->maxItemQuantity > 0) {
+                if ('cart_products' === $objRule->quantityMode) {
+                    $intTotal = Isotope::getCart()->countItems();
+                } elseif ('cart_items' === $objRule->quantityMode) {
+                    $intTotal = Isotope::getCart()->sumItemsQuantity();
+                } else {
+                    $objItem = Isotope::getCart()->getItemForProduct($objSource->getRelated('pid'));
+                    $intTotal = (null === $objItem) ? 0 : $objItem->quantity;
                 }
+
+                if (($objRule->minItemQuantity > 0 && $objRule->minItemQuantity > $intTotal) || ($objRule->maxItemQuantity > 0 && $objRules->maxItemQuantity < $intTotal)) {
+                    continue;
+                }
+            }
+
+            // We're unable to apply variant price rules to low_price (see #3189)
+            if ('low_price' === $strField && 'variants' === $objRule->productRestrictions) {
+                continue;
+            }
+
+            if ($objRule->isPercentage()) {
+                $fltDiscount = 100 + $objRule->getPercentage();
+                $fltDiscount = round($fltPrice - ($fltPrice / 100 * $fltDiscount), 10);
+
+                $precision = Isotope::getConfig()->priceRoundPrecision;
+                $factor    = 10 ** 2;
+                $up        = $fltDiscount > 0 ? 'ceil' : 'floor';
+                $down      = $fltDiscount > 0 ? 'floor' : 'ceil';
+
+                switch ($objRule->rounding) {
+                    case Rule::ROUND_NORMAL:
+                        $fltDiscount = round($fltDiscount, $precision);
+                        break;
+
+                    case Rule::ROUND_UP:
+                        $fltDiscount = $up($fltDiscount * $factor) / $factor;
+                        break;
+
+                    case Rule::ROUND_DOWN:
+                    default:
+                        $fltDiscount = $down($fltDiscount * $factor) / $factor;
+                        break;
+                }
+
+                $fltPrice = $fltPrice - $fltDiscount;
+            } else {
+                $fltPrice = $fltPrice + $objRule->discount;
             }
         }
 
         return $fltPrice;
     }
-
 
     /**
      * Add cart rules to surcharges

--- a/system/modules/isotope_rules/library/Isotope/Rules.php
+++ b/system/modules/isotope_rules/library/Isotope/Rules.php
@@ -121,12 +121,12 @@ class Rules extends Controller
                         break;
 
                     case Rule::ROUND_UP:
-                        $fltDiscount = $up === 'ceil' ? $up(round($fltDiscount * $factor, 4)) / $factor : $up($fltDiscount * $factor) / $factor;
+                        $fltDiscount = $up(round($fltDiscount * $factor, 4)) / $factor;
                         break;
 
                     case Rule::ROUND_DOWN:
                     default:
-                        $fltDiscount = $down === 'ceil' ? $down(round($fltDiscount * $factor, 4)) / $factor : $down($fltDiscount * $factor) / $factor;
+                        $fltDiscount = $down(round($fltDiscount * $factor, 4)) / $factor;
                         break;
                 }
 

--- a/system/modules/isotope_rules/library/Isotope/Rules.php
+++ b/system/modules/isotope_rules/library/Isotope/Rules.php
@@ -121,12 +121,12 @@ class Rules extends Controller
                         break;
 
                     case Rule::ROUND_UP:
-                        $fltDiscount = $up($fltDiscount * $factor) / $factor;
+                        $fltDiscount = $up === 'ceil' ? $up(round($fltDiscount * $factor, 4)) / $factor : $up($fltDiscount * $factor) / $factor;
                         break;
 
                     case Rule::ROUND_DOWN:
                     default:
-                        $fltDiscount = $down($fltDiscount * $factor) / $factor;
+                        $fltDiscount = $down === 'ceil' ? $down(round($fltDiscount * $factor, 4)) / $factor : $down($fltDiscount * $factor) / $factor;
                         break;
                 }
 


### PR DESCRIPTION
see https://github.com/isotope/core/issues/2559#issuecomment-2580593127

I chose a round precision of 4 because this has already been used at https://github.com/isotope/core/blob/d72bb80f13d014f609a0dea8cd8c3bb84fe6c5da/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php#L237

Feel free to modify :-) 