### PR TITLE
Fix incorrect date_paid and date_shipped in order show

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductCollection/Callback.php
@@ -220,7 +220,7 @@ class Callback extends Backend
             $strBuffer .= '
   <tr>
     <td class="tl_label">' . Format::dcaLabel($dc->table, $field) . ' <small>'.$field.'</small></td>
-    <td>' . Format::dcaValue($dc->table, $field, $objOrder->{$field}, $dc) . '</td>
+    <td>' . ($objOrder->{$field} ? Format::dcaValue($dc->table, $field, $objOrder->{$field}, $dc) : '') . '</td>
     <td>' . implode(' ', $operations) . '</td>
   </tr>';
         }


### PR DESCRIPTION
If an order does not have date_paid or date_shipped set, the current date and time is displayed in the backend.
This is fixed by this PR.

Before:
![image](https://github.com/user-attachments/assets/187d6fa1-f314-42d5-8cd5-48b81c23051f)
![image](https://github.com/user-attachments/assets/437037b5-6265-47fd-9536-ed4168cc9d65)

After:
![image](https://github.com/user-attachments/assets/a6acb532-5783-44c8-ae99-0edc2fc17a6d)
