### PR TITLE
Do not hard code `.tl_filter` width

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/ProductCollection/Panel.php
+++ b/system/modules/isotope/library/Isotope/Backend/ProductCollection/Panel.php
@@ -58,16 +58,11 @@ class Panel extends Backend
     .tl_filter {
         display: flex;
         align-items: center;
-        width: 80%;
+        width: auto;
         margin-left: 2em;
     }
     .tl_filter .tl_select {
         max-width: none;
-    }
-}
-@media (min-width: 1200px) {
-    .tl_filter {
-        width: 60%;
     }
 }
 </style>


### PR DESCRIPTION
If you add `'sorting' => true` to more fields of `tl_iso_product_collection` in a DCA adjustment, the filters will currently overflow:

![image](https://github.com/user-attachments/assets/06770a85-a828-4950-a726-4706f7d10621)

This PR fixes that by setting the `width` of `.tl_filter` to `auto` instead:

![image](https://github.com/user-attachments/assets/882a0fdc-fe74-439d-b37f-5eef72a4c17a)