### PR TITLE
Fix TypeError if tax rate has empty `rate` field

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend/TaxRate/Callback.php
+++ b/system/modules/isotope/library/Isotope/Backend/TaxRate/Callback.php
@@ -117,6 +117,10 @@ class Callback extends Permission
     {
         $arrRate = StringUtil::deserialize($row['rate']);
 
+        if (!is_array($arrRate)) {
+            return $row['name'];
+        }
+        
         if ($row['config'] && !$arrRate['unit']) {
             Isotope::setConfig(Config::findByPk($row['config']));
 


### PR DESCRIPTION
If a tax rate has an empty `rate` field, for example because someone created a new tax rate but didn't save it, the tax rates cannot be edited anymore via the backend because of the following error. This PR fixes the error.

```
TypeError:
Cannot access offset of type string on string

  at vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Backend/TaxRate/Callback.php:125
  at Isotope\Backend\TaxRate\Callback->listRow()
     (vendor/contao/core-bundle/src/Resources/contao/classes/DataContainer.php:1820)
  at Contao\DataContainer->generateRecordLabel()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:5064)
  at Contao\DC_Table->listView()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:313)
  at Contao\DC_Table->showAll()
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/BackendModule/BackendOverview.php:245)
  at Isotope\BackendModule\BackendOverview->getModule()
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/BackendModule/BackendOverview.php:84)
  at Isotope\BackendModule\BackendOverview->generate()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:439)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:44)      
```

This is the record that causes this.
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/95e8c8b9-1389-46ae-9a0b-cba08c3c8481" />
