### PR TITLE
Fix possible runtime error when product is not registered

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCategory.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCategory.php
@@ -63,8 +63,9 @@ class ProductCategory extends Model
      */
     public static function findByPidForPublishedPages($intProduct, array $arrOptions = array())
     {
-        // Register the model to prevent a runtime error
+        // Register model to prevent eager loading of product data (see isotope/core#2570)
         Product::findByPk($intProduct);
+
         $arrOptions = static::getFindByPidForPublishedPagesOptions($intProduct, $arrOptions);
 
         return parent::find($arrOptions);

--- a/system/modules/isotope/library/Isotope/Model/ProductCategory.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCategory.php
@@ -63,6 +63,8 @@ class ProductCategory extends Model
      */
     public static function findByPidForPublishedPages($intProduct, array $arrOptions = array())
     {
+        // Register the model to prevent a runtime error
+        Product::findByPk($intProduct);
         $arrOptions = static::getFindByPidForPublishedPagesOptions($intProduct, $arrOptions);
 
         return parent::find($arrOptions);


### PR DESCRIPTION
`ProductCategory::findByPidForPublishedPages($productId)` causes a runtime error when the given product is not registered in the model registry:

```
Cannot instantiate abstract class Isotope\Model\Product
in vendor/contao/core-bundle/src/Resources/contao/library/Contao/Model.php (line 182)
```

`Contao\Model::__construct()` tries to load the relations for `tl_iso_product_category.pid`, so it instanciates `Isotope\Model\Product` skipping the type agent for `tl_iso_product`.

Solution: register the product.

This issue does not appear in vanilla isotope, but may appear when you have custom bundles extending isotope.
Reproduced in Contao 4.13.

Steps to reproduce:
```php
$product = Product::findByPk($myId);
$product->detach(false);
ProductCategory::findByPidForPublishedPages($myId);
```