### PR TITLE
Fix product collection model type

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/ProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection.php
@@ -1955,7 +1955,7 @@ abstract class ProductCollection extends TypeAgent implements IsotopeProductColl
      */
     public static function createFromCollection(IsotopeProductCollection $objSource)
     {
-        $objCollection = new static();
+        $objCollection = new (static::$arrModelTypes[static::$modelType])();
         $objConfig = $objSource->getConfig();
 
         if (null === $objConfig) {

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection.php
@@ -69,7 +69,8 @@ use Contao\Model\Registry;
  */
 abstract class ProductCollection extends TypeAgent implements IsotopeProductCollection
 {
-
+    protected static $modelType = '';
+ 
     /**
      * Name of the current table
      * @var string

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection/Cart.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection/Cart.php
@@ -29,6 +29,8 @@ use Isotope\Model\ProductCollection;
  */
 class Cart extends ProductCollection implements IsotopeOrderableCollection
 {
+    protected static $modelType = 'cart';
+
     /**
      * Cookie hash value
      * @var string
@@ -345,7 +347,7 @@ class Cart extends ProductCollection implements IsotopeOrderableCollection
         // Create new cart
         if ($objCart === null) {
             $objConfig = Config::findByRootPageOrFallback($objPage->rootId);
-            $objCart   = new static();
+            $objCart   = new (static::$arrModelTypes[static::$modelType])();
 
             // Can't call the individual rows here, it would trigger markModified and a save()
             $objCart->setRow(array_merge($objCart->row(), array(

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection/Favorites.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection/Favorites.php
@@ -22,6 +22,8 @@ use Isotope\Model\ProductCollection;
 
 class Favorites extends ProductCollection
 {
+    protected static $modelType = 'favorites';
+
     /**
      * Name of the temporary collection cookie
      */
@@ -78,7 +80,7 @@ class Favorites extends ProductCollection
         // Create new collection
         if (null === $collection) {
             $config = Config::findByRootPageOrFallback($objPage->rootId);
-            $collection = new static();
+            $collection = new (static::$arrModelTypes[static::$modelType])();
 
             // Can't call the individual rows here, it would trigger markModified and a save()
             $collection->setRow(array_merge($collection->row(), array(

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php
@@ -54,6 +54,7 @@ class Order extends ProductCollection implements IsotopePurchasableCollection
     public const STATUS_UPDATE_SKIP_NOTIFICATION = 1;
     public const STATUS_UPDATE_SKIP_LOG = 2;
 
+    protected static $modelType = 'order';
 
     /**
      * @inheritdoc

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection/Wishlist.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection/Wishlist.php
@@ -18,6 +18,8 @@ use Isotope\Model\ProductCollection;
 
 class Wishlist extends ProductCollection
 {
+    protected static $modelType = 'wishlist';
+
     public function getName()
     {
         return $this->name;
@@ -38,7 +40,7 @@ class Wishlist extends ProductCollection
 
     public static function createForCurrentUser()
     {
-        $wishlist = new static();
+        $wishlist = new (static::$arrModelTypes[static::$modelType])();
         $wishlist->setName($GLOBALS['TL_LANG']['MSC']['defaultWishlistName'] ?: 'Wishlist 1');
         $wishlist->member = FrontendUser::getInstance()->id;
         $wishlist->store_id = (int) static::getCurrentStoreId();

--- a/system/modules/isotope/library/Isotope/Model/TypeAgent.php
+++ b/system/modules/isotope/library/Isotope/Model/TypeAgent.php
@@ -56,7 +56,8 @@ abstract class TypeAgent extends Model
             }
         }
 
-        if ($this->arrData['type'] == '') {
+        // Type may be unset
+        if (!($this->arrData['type'] ?? null)) {
             throw new \RuntimeException(sprintf(
                 '%s (%s.%s) has no model type',
                 static::class, static::$strTable, $this->arrData['id']


### PR DESCRIPTION
### Problem

The TypeAgent breaks when you try to extend any subclass of ProductCollection. Example:

```php
// config.php
\Isotope\Model\ProductCollection::registerModelType('cart', \MyCustomNamepsace\Cart::class);
```

Doing so leads to an error when Isotope tries to create a new cart for the current user:
`Isotope\Model\ProductCollection\Cart (tl_iso_product_collection.) has no model type`. The actual issue is in `\Isotope\Model\ProductCollection\Cart` line 348:

```php
if ($objCart === null) {
    $objConfig = Config::findByRootPageOrFallback($objPage->rootId);
    $objCart   = new static();
    // .......
```

Calling `new static()` creates a new instance of type agent, that is not a valid model type anymore, because `\MyCustomNamepsace\Cart::class` should be the model type.

### Expected behavior

The ProductCollection should dynamicly load the correct model type and the related class.

```php
// Pseudo code
$objCart   = new {static::getClassname()} ();
```

### Suggestion

Create a new property `ProductCollection::$modelType` and set it correctly in each class. Example for `Cart`:

```php
protected static $modelType = 'cart';

// ....
public static function findForCurrentStore()
{
	// ...
	if ($objCart === null) {
		$objConfig = Config::findByRootPageOrFallback($objPage->rootId);
		$objCart   = new (static::$arrModelTypes[static::$modelType])();
```
