### PR TITLE
Fix the pid reference for folder downloads

### DIFF
--- a/system/modules/isotope/library/Isotope/Model/Download.php
+++ b/system/modules/isotope/library/Isotope/Model/Download.php
@@ -42,7 +42,7 @@ class Download extends Model
 
         if ('folder' === $objFile->type) {
             $arrFiles = array();
-            $objFiles = FilesModel::findBy(array("pid=?", "type='file'"), array($objFile->id));
+            $objFiles = FilesModel::findBy(array("pid=?", "type='file'"), array($objFile->uuid));
 
             if (null !== $objFiles) {
                 while ($objFiles->next()) {


### PR DESCRIPTION
### Description

Configuring a folder as a download will never render bought downloads because the `pid` references the `uuid` and not the `id ` (files / folders). This PR fixes this behavior :)

```diff
if ('folder' === $objFile->type) {
    $arrFiles = array();
-    $objFiles = FilesModel::findBy(array("pid=?", "type='file'"), array($objFile->id));
+    $objFiles = FilesModel::findBy(array("pid=?", "type='file'"), array($objFile->uuid));
```

**See DBAFS:**
https://github.com/contao/contao/blob/98274a6b07f4877dc369ee7975f9c256c54dd576/core-bundle/src/Resources/contao/library/Contao/Dbafs.php#L269