### PR TITLE
Update ProductCollectionSurcharge Rule.php

### DIFF
--- a/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
+++ b/system/modules/isotope_rules/library/Isotope/Model/ProductCollectionSurcharge/Rule.php
@@ -74,6 +74,7 @@ class Rule extends ProductCollectionSurcharge implements IsotopeProductCollectio
         $objSurcharge->tax_class = 0;
         $objSurcharge->before_tax = true;
         $objSurcharge->addToTotal = true;
+        $objSurcharge->source_id = $objRule->id;
 
         // Product or producttype restrictions
         if ($objRule->productRestrictions != '' && $objRule->productRestrictions != 'none') {


### PR DESCRIPTION
Source Id for a rule is always stored as 0, inside table `tl_iso_product_collection_surcharge`. With this change source_id is stored correctly.
<img width="1579" height="759" alt="screenshot_2021-02-16_at_11 48 56" src="https://github.com/user-attachments/assets/0d777c06-22b4-419a-8be0-a27b3e5ab15d" />
