### PR TITLE
Add order state for free orders

### DIFF
--- a/system/modules/isotope/dca/tl_iso_config.php
+++ b/system/modules/isotope/dca/tl_iso_config.php
@@ -104,7 +104,7 @@ $GLOBALS['TL_DCA']['tl_iso_config'] = array
             {pricing_legend},priceDisplay,currencyFormat,priceRoundPrecision,priceRoundIncrement;
             {currency_legend},currency,currencyPosition,currencySymbol;
             {converter_legend:hide},priceCalculateFactor,priceCalculateMode,currencyAutomator;
-            {order_legend:hide},orderPrefix,orderDigits,orderstatus_new,orderstatus_error,orderDetailsModule;
+            {order_legend:hide},orderPrefix,orderDigits,orderstatus_new,orderstatus_error,orderstatus_no_payment,orderDetailsModule;
             {config_legend},templateGroup,cartMinSubtotal;
             {products_legend},newProductPeriod;
             {analytics_legend},ga_enable',
@@ -550,6 +550,17 @@ $GLOBALS['TL_DCA']['tl_iso_config'] = array
             'relation'              => array('type'=>'hasOne', 'load'=>'lazy'),
         ),
         'orderstatus_error' => array
+        (
+            'exclude'               => true,
+            'filter'                => true,
+            'inputType'             => 'select',
+            'foreignKey'            => \Isotope\Model\OrderStatus::getTable().'.name',
+            'options_callback'      => array('\Isotope\Backend', 'getOrderStatus'),
+            'eval'                  => array('mandatory'=>true, 'includeBlankOption'=>true, 'tl_class'=>'w50'),
+            'sql'                   => "int(10) unsigned NOT NULL default '0'",
+            'relation'              => array('type'=>'hasOne', 'load'=>'lazy'),
+        ),
+        'orderstatus_no_payment' => array
         (
             'exclude'               => true,
             'filter'                => true,

--- a/system/modules/isotope/languages/da/tl_iso_config.xlf
+++ b/system/modules/isotope/languages/da/tl_iso_config.xlf
@@ -327,6 +327,12 @@
       <trans-unit id="tl_iso_config.orderstatus_error.1">
         <source>Select an order status if something goes wrong (e.g. payment).</source>
       </trans-unit>
+       <trans-unit id="tl_iso_config.orderstatus_error.0">
+         <source>Status for free orders</source>
+       </trans-unit>
+       <trans-unit id="tl_iso_config.orderstatus_error.1">
+         <source>Choose a matching status for free orders. A payment module can override this.</source>
+       </trans-unit>
       <trans-unit id="tl_iso_config.orderDetailsModule.0">
         <source>Module for backend view</source>
       </trans-unit>

--- a/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php
+++ b/system/modules/isotope/library/Isotope/Model/ProductCollection/Order.php
@@ -227,7 +227,11 @@ class Order extends ProductCollection implements IsotopePurchasableCollection
 
         // Set order status only if a payment module has not already set it
         if ($this->order_status == 0) {
-            $this->updateOrderStatus($this->getRelated('config_id')->orderstatus_new);
+            if(parent::requiresPayment()) {
+                $this->updateOrderStatus($this->getRelated('config_id')->orderstatus_new);
+            } else {
+                $this->updateOrderStatus($this->getRelated('config_id')->orderstatus_no_payment);
+            }
         }
 
         // !HOOK: post-process checkout


### PR DESCRIPTION
Adding a field to set the status of free orders so that it can be done flexibly, decoupled from the status of new orders.