### PR TITLE
Add a null check to prevent an undefined array key warning

### DIFF
--- a/system/modules/isotope/library/Isotope/Backend.php
+++ b/system/modules/isotope/library/Isotope/Backend.php
@@ -110,7 +110,7 @@ class Backend extends ContaoBackend
             return $arrSubdivisions[$country][$subdivision];
         }
 
-        if (\is_array($arrSubdivisions[$country])) {
+        if (\is_array($arrSubdivisions[$country] ?? null)) {
             foreach ($arrSubdivisions[$country] as $regionGroup) {
                 if (\is_array($regionGroup)) {
                     foreach ($regionGroup as $regions) {


### PR DESCRIPTION
My sentry gets flooded with `undefined array key ""` warnings.

<img width="2672" height="2116" alt="Bildschirmfoto 2025-12-01 um 08 54 53" src="https://github.com/user-attachments/assets/053d12dd-ed7f-43a6-b667-4179fa9c4409" />
